### PR TITLE
Fix dependency-free locale Pages build

### DIFF
--- a/scripts/runtime/html_document.py
+++ b/scripts/runtime/html_document.py
@@ -6,21 +6,21 @@
 
 The course validators inspect authored HTML but do not sanitize learner input. Even so, their view
 of script boundaries must agree with a browser: a regex that misses a malformed end tag can hide
-code from a gate. BeautifulSoup's pinned lxml backend handles those recovery cases and keeps the
-parsing policy in one place.
+code from a gate. BeautifulSoup's pinned lxml backend handles those recovery cases. The package-free
+strict parser is reserved for deterministic projection after that browser-tolerant validation.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from html.parser import HTMLParser
 from typing import Iterable
-
-from bs4 import BeautifulSoup
 
 
 @dataclass(frozen=True)
 class RawTextBlock:
-    """One browser-parsed raw-text element and its source-relative body position."""
+    """One raw-text element and its source-relative body position."""
 
     attributes: dict[str, str]
     body: str
@@ -71,8 +71,77 @@ def _next_start_tag(raw: str, name: str, start: int) -> int:
     return -1
 
 
+class _StrictRawTextParser(HTMLParser):
+    """Locate verified raw-text elements without optional third-party packages."""
+
+    def __init__(self, raw: str, name: str) -> None:
+        super().__init__(convert_charrefs=False)
+        self.raw = raw
+        self.name = name.casefold()
+        self.line_starts = [0, *(match.end() for match in re.finditer("\n", raw))]
+        self.active: tuple[int, int, dict[str, str]] | None = None
+        self.blocks: list[RawTextBlock] = []
+
+    def absolute_offset(self) -> int:
+        line, column = self.getpos()
+        return self.line_starts[line - 1] + column
+
+    @staticmethod
+    def attributes(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
+        return {str(key).casefold(): str(value or "") for key, value in attrs}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.casefold() != self.name:
+            return
+        if self.active is not None:
+            raise ValueError(f"nested {self.name} start tag")
+        element_start = self.absolute_offset()
+        body_start = _tag_end(self.raw, element_start)
+        self.active = (element_start, body_start, self.attributes(attrs))
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.casefold() == self.name:
+            raise ValueError(f"self-closing {self.name} is not a valid raw-text boundary")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.casefold() != self.name:
+            return
+        if self.active is None:
+            raise ValueError(f"unmatched {self.name} end tag")
+        element_start, body_start, attributes = self.active
+        close_start = self.absolute_offset()
+        close_end = _tag_end(self.raw, close_start)
+        self.blocks.append(
+            RawTextBlock(
+                attributes,
+                self.raw[body_start:close_start],
+                body_start,
+                element_start,
+                close_end,
+            )
+        )
+        self.active = None
+
+    def finish(self) -> list[RawTextBlock]:
+        self.feed(self.raw)
+        self.close()
+        if self.active is not None:
+            raise ValueError(f"unterminated {self.name} element")
+        return self.blocks
+
+
+def raw_text_blocks_strict(raw: str, name: str) -> list[RawTextBlock]:
+    """Return exact raw-text spans for source that already passed browser validation."""
+
+    if name.casefold() not in {"script", "style"}:
+        raise ValueError(f"unsupported raw-text element: {name}")
+    return _StrictRawTextParser(raw, name).finish()
+
+
 def raw_text_blocks(raw: str, name: str) -> list[RawTextBlock]:
     """Return raw-text element blocks after lxml establishes browser-compatible boundaries."""
+
+    from bs4 import BeautifulSoup
 
     blocks = []
     cursor = 0
@@ -108,6 +177,8 @@ def raw_text_blocks(raw: str, name: str) -> list[RawTextBlock]:
 
 def script_body_by_id(raw: str, element_id: str) -> str | None:
     """Return a script element body selected by its exact id."""
+
+    from bs4 import BeautifulSoup
 
     element = BeautifulSoup(raw, "lxml").find("script", id=element_id)
     if element is None:

--- a/scripts/translate/translate_html_segments.py
+++ b/scripts/translate/translate_html_segments.py
@@ -30,7 +30,7 @@ for _p in (Path(__file__).resolve(), *Path(__file__).resolve().parents):
         sys.path.insert(0, str(_p / "scripts"))
         break
 from _bootstrap import find_repo_root
-from runtime.html_document import raw_text_blocks
+from runtime.html_document import raw_text_blocks_strict
 
 ROOT = find_repo_root(Path(__file__).resolve())
 TRANSLATION_REVISION = "locale-editorial-v5-source-draft"
@@ -195,7 +195,7 @@ def useful(text: str) -> bool:
 
 def script_segments(raw: str) -> list[Segment]:
     out: list[Segment] = []
-    for script in raw_text_blocks(raw, "script"):
+    for script in raw_text_blocks_strict(raw, "script"):
         body = script.body
         if "src" in script.attributes or "application/json" in script.attributes.get("type", "").casefold():
             continue

--- a/tests/validation/test_build_pages_dependencies.py
+++ b/tests/validation/test_build_pages_dependencies.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -62,6 +63,36 @@ class BuildPagesDependencyTests(unittest.TestCase):
         result = self.run_preflight(pull_materials=True)
         self.assertEqual(2, result.returncode)
         self.assertIn("missing material tools", result.stderr)
+
+    def test_locale_projection_runs_without_material_parser_packages(self) -> None:
+        source = (
+            '<html lang="en"><body><p>Hello learner</p>'
+            '<script>const ui={label:"Run exercise"};</script></body></html>'
+        )
+        target = source.replace('lang="en"', 'lang="es"').replace(
+            "Hello learner", "Hola, estudiante"
+        ).replace("Run exercise", "Ejecutar ejercicio")
+        program = (
+            "import sys\n"
+            "sys.modules['bs4'] = None\n"
+            "from translate.locale_projection import project_locale_html\n"
+            f"source = {source!r}\n"
+            f"target = {target!r}\n"
+            "result = project_locale_html(source, target, {})\n"
+            "assert 'Hola, estudiante' in result\n"
+            "assert 'Ejecutar ejercicio' in result\n"
+        )
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(ROOT / "scripts")
+        result = subprocess.run(
+            [sys.executable, "-c", program],
+            cwd=ROOT,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_html_document.py
+++ b/tests/validation/test_html_document.py
@@ -16,7 +16,12 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from _bootstrap import add_script_paths  # noqa: E402
 
 add_script_paths(ROOT / "scripts")
-from html_document import raw_text_blocks, script_body_by_id, without_elements  # noqa: E402
+from html_document import (  # noqa: E402
+    raw_text_blocks,
+    raw_text_blocks_strict,
+    script_body_by_id,
+    without_elements,
+)
 
 
 class HtmlDocumentTests(unittest.TestCase):
@@ -36,6 +41,23 @@ class HtmlDocumentTests(unittest.TestCase):
         self.assertEqual(block.attributes, {"type": "module"})
         self.assertEqual(block.body, "\nrun();\n")
         self.assertEqual(raw[block.body_start:block.body_start + len(block.body)], block.body)
+
+    def test_strict_projection_matches_browser_parser_for_served_html(self) -> None:
+        paths = sorted((ROOT / "web").rglob("*.html")) + sorted((ROOT / "i18n").rglob("*.html"))
+        self.assertTrue(paths)
+        for path in paths:
+            raw = path.read_text(encoding="utf-8")
+            for name in ("script", "style"):
+                with self.subTest(path=path.relative_to(ROOT), name=name):
+                    browser = raw_text_blocks(raw, name)
+                    strict = raw_text_blocks_strict(raw, name)
+                    self.assertEqual(browser, strict)
+
+    def test_strict_projection_matches_browser_recovery_syntax(self) -> None:
+        for ending in ("</script foo=\"bar\">", "</script\t\n bar>"):
+            with self.subTest(ending=ending):
+                raw = f"<script>danger(){ending}<p>visible</p>"
+                self.assertEqual(raw_text_blocks(raw, "script"), raw_text_blocks_strict(raw, "script"))
 
     def test_comments_and_longer_element_names_are_not_script_boundaries(self) -> None:
         raw = (


### PR DESCRIPTION
## Summary

Make deterministic Pages assembly independent of the optional material-parser environment. Locale projection now uses a standard-library raw-text parser after the browser-tolerant validation gate has approved the source.

## Issue link

Closes #8

## Current release target

- Course: bundle-wide Pages assembly
- Production: GitHub Pages
- Tooling: base Python for deterministic assembly; pinned material tools remain required for live refresh
- Bundle scope: locale overlays and shared HTML parsing

## Surfaces touched

- [ ] `web/`
- [ ] `i18n/`
- [x] `scripts/`
- [ ] `docs/`
- [ ] `materials/source governance`

## Blast radius checked

Compared the strict and browser-tolerant script/style boundaries across every HTML file under `web/` and `i18n/`. Exercised real locale projection with `bs4` unavailable. ReACS fast and ship tiers covered source parsing, locale assembly, navigation, artifact links, and mutation suites.

## Validation evidence

- [x] `release_gate.py --tier fast --no-write` — PASS in Apple Container, 63/63
- [x] `release_gate.py --tier ship` — PASS through Apple Container `build-pages`, 88/88
- [ ] Browser/runtime check — NOT APPLICABLE; no learner runtime changed
- [x] Build check — PASS; English, Spanish, and Portuguese Pages artifacts assembled and passed link audits

## Security and source impact

No dependency, permission, workflow, secret, source, license, or deploy-authority change. The build-time import surface is smaller. Browser-tolerant validation still requires the pinned parser and remains authoritative.

## External release follow-up

`release_change_reminder.py --commit-range origin/main..HEAD` — PASS; no conditional follow-up.

- [x] Threat and architecture assessment — NOT APPLICABLE
- [x] Authoritative vulnerability and secret scans — NOT APPLICABLE
- [x] Open-source and license review — NOT APPLICABLE
- [x] Final-artifact SBOM, malware, and release evidence — NOT APPLICABLE

## Human ownership

The author owns the complete diff, merge, and release. Independent review is requested from `lisguo` before merge.

## Release notes

Learner-facing: restores complete localized Pages publication.

Browser/runtime integration: none.

Governance/process: adds a portable regression for clean locale builds.

## Risk and rollback

Risk is disagreement between the strict projection parser and browser recovery. Exhaustive parity tests cover every served HTML file and malformed closing-tag recovery. Revert `ec86011` to restore the prior implementation.

## Out of scope

No learner prose or localized source changed; localized prose remains byte-identical. Live material-refresh behavior is unchanged.
