### PR TITLE
Repair reproducible Pages builders

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -130,9 +130,10 @@ jobs:
       - name: Build the client-side static site
         run: BUILD_PAGES_PULL_MATERIALS=0 BUILD_PAGES_REUSE_VALIDATION=1 bash scripts/build/build_pages.sh public
       - name: Install the pinned host-browser API
+        working-directory: scripts/runtime
         run: |
           corepack enable
-          pnpm install --dir scripts/runtime --frozen-lockfile --ignore-scripts
+          pnpm install --frozen-lockfile --ignore-scripts
       - name: Verify and exercise the exact Pages artifact
         run: |
           python3 scripts/skills/skill_renderer_runtime_audit.py --site-root public --engine current

--- a/scripts/build/project_source_tree.py
+++ b/scripts/build/project_source_tree.py
@@ -44,7 +44,20 @@ def is_authoring_source(path: Path) -> bool:
     return not any(parts[:len(prefix)] == prefix for prefix in GENERATED_OUTPUT_PREFIXES)
 
 
-def source_files(root: Path) -> list[Path]:
+def _artifact_subtree(root: Path, output: Path) -> Path | None:
+    """Return an in-repository artifact path, rejecting output that contains the source root."""
+    root = root.resolve()
+    output = output.resolve()
+    if root == output or root.is_relative_to(output):
+        raise ValueError(f"artifact root must not contain the source root: {output}")
+    try:
+        return output.relative_to(root)
+    except ValueError:
+        return None
+
+
+def source_files(root: Path, output: Path | None = None) -> list[Path]:
+    artifact_subtree = _artifact_subtree(root, output) if output is not None else None
     raw = subprocess.check_output(
         ["git", "-C", str(root), "ls-files", "--cached", "--others", "--exclude-standard", "-z"]
     )
@@ -53,7 +66,14 @@ def source_files(root: Path) -> list[Path]:
         for item in raw.split(b"\0")
         if item
         for path in (Path(item.decode()),)
-        if is_authoring_source(path) and (root / path).is_file()
+        if (
+            is_authoring_source(path)
+            and not (
+                artifact_subtree is not None
+                and (path == artifact_subtree or artifact_subtree in path.parents)
+            )
+            and (root / path).is_file()
+        )
     )
 
 
@@ -155,11 +175,13 @@ def project_json_urls(source_file: Path, artifact_file: Path, output: Path,
 
 
 def project(root: Path, output: Path) -> tuple[int, list[str]]:
+    root = root.resolve()
+    output = output.resolve()
     findings = [
         f"tracked generated output must be rebuilt, not versioned: {path}"
         for path in tracked_generated_files(root)
     ]
-    files = source_files(root)
+    files = source_files(root, output)
     file_set = set(files)
     for relative in files:
         source = root / relative
@@ -254,6 +276,33 @@ class ProjectionTests(unittest.TestCase):
             )
             evidence = json.loads((output / "nested" / "evidence.json").read_text(encoding="utf-8"))
             self.assertEqual("../source/github/SKILL.html", evidence["links"][0]["href"])
+
+    def test_arbitrary_in_tree_artifact_never_becomes_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / "repo"
+            output = root / "any-future-build-name"
+            root.mkdir()
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            (root / "SKILL.html").write_text("<p>source</p>", encoding="utf-8")
+            subprocess.run(["git", "-C", str(root), "add", "SKILL.html"], check=True)
+
+            output.mkdir()
+            (output / "stale.html").write_text("<p>old artifact</p>", encoding="utf-8")
+            first_count, first_findings = project(root, output)
+            second_count, second_findings = project(root, output)
+
+            self.assertEqual((first_count, first_findings), (1, []))
+            self.assertEqual((second_count, second_findings), (1, []))
+            self.assertEqual((output / "SKILL.html").read_text(encoding="utf-8"), "<p>source</p>")
+            self.assertFalse((output / output.name).exists())
+
+    def test_artifact_root_cannot_contain_source_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp) / "repo"
+            root.mkdir()
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            with self.assertRaises(ValueError):
+                project(root, root)
 
 
 def main() -> int:

--- a/scripts/validation/contribution_safety_audit.py
+++ b/scripts/validation/contribution_safety_audit.py
@@ -24,6 +24,12 @@ from _bootstrap import find_repo_root
 
 ROOT = find_repo_root(Path(__file__).resolve())
 NVIDIA_APACHE_COPYRIGHT = "Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved."
+BROWSER_RUNTIME_CONSUMERS = (
+    "release_gate.py --tier ship",
+    "skill_renderer_runtime_audit.py",
+    "runtime_integration_browser_audit.py",
+    "branch_preview_runtime_audit.py",
+)
 DECISION_POLICY = {
     "default": "deny",
     "authorization_record": "external-not-repository",
@@ -253,6 +259,56 @@ def workflow_jobs(workflow: str) -> list[tuple[str, str]]:
         r"(?m)^  ([A-Za-z0-9_-]+):\s*$", body
     )]
     return [(name, workflow_job(workflow, name)) for name in names]
+
+
+def workflow_steps(job: str) -> list[str]:
+    """Discover every top-level step in one GitHub Actions job."""
+    starts = list(re.finditer(r"(?m)^      - (?:name:|uses:|run:)\s*", job))
+    return [
+        job[match.start() : starts[index + 1].start() if index + 1 < len(starts) else len(job)]
+        for index, match in enumerate(starts)
+    ]
+
+
+def audit_browser_runtime_jobs(
+    workflow: str, rel: str, code_prefix: str,
+) -> list[dict[str, str]]:
+    """Require the nested pinned runtime in every job that consumes its browser API."""
+    out: list[dict[str, str]] = []
+    install = "pnpm install --frozen-lockfile --ignore-scripts"
+    for job_name, job in workflow_jobs(workflow):
+        consumer_positions = [
+            job.index(token) for token in BROWSER_RUNTIME_CONSUMERS if token in job
+        ]
+        if not consumer_positions:
+            continue
+        install_steps = [step for step in workflow_steps(job) if install in step]
+        correct_steps = [
+            step for step in install_steps
+            if "working-directory: scripts/runtime" in step
+            and "--dir scripts/runtime" not in step
+        ]
+        if len(correct_steps) != 1:
+            out.append(finding(
+                f"{code_prefix}-browser-runtime-lock", rel,
+                f"browser-backed job {job_name} does not install the nested pinned runtime exactly once",
+                "run pnpm from scripts/runtime with the frozen lockfile in every browser-backed job",
+            ))
+            continue
+        install_position = job.index(correct_steps[0]) + correct_steps[0].index(install)
+        if install_position > min(consumer_positions):
+            out.append(finding(
+                f"{code_prefix}-browser-runtime-order", rel,
+                f"browser-backed job {job_name} installs its runtime after the first consumer",
+                "install the pinned browser API before browser-backed validation",
+            ))
+        if 'node-version: "24"' not in job:
+            out.append(finding(
+                f"{code_prefix}-node-runtime", rel,
+                f"browser-backed job {job_name} does not use the supported Node.js 24 runtime",
+                "run browser-backed validation on Node.js 24",
+            ))
+    return out
 
 
 def workflow_has_trigger(workflow: str, trigger: str) -> bool:
@@ -755,31 +811,9 @@ def audit_repo(
     require(pages, "--timing-report docs/validation/release-gate-timings.json",
             ".github/workflows/pages.yml", "github-gate-timing", out,
             "retain per-command gate timing evidence")
-    test_job = workflow_job(pages, "test")
-    browser_runtime_install = "pnpm install --frozen-lockfile --ignore-scripts"
-    browser_runtime_context = (
-        "working-directory: scripts/runtime",
-        browser_runtime_install,
-    )
-    if any(token not in test_job for token in browser_runtime_context):
-        out.append(finding(
-            "github-browser-runtime-lock", ".github/workflows/pages.yml",
-            "the GitHub test job does not install the nested pinned host-browser API",
-            "run pnpm from scripts/runtime with --frozen-lockfile before the shared ship gate",
-        ))
-    elif test_job.index(browser_runtime_install) > test_job.index("release_gate.py --tier ship"):
-        out.append(finding(
-            "github-browser-runtime-order", ".github/workflows/pages.yml",
-            "the pinned host-browser API is installed after Chromium-backed validation runs",
-            "install the pinned browser API before the shared ship gate",
-        ))
-    for job_name in ("test", "build-and-verify"):
-        if 'node-version: "24"' not in workflow_job(pages, job_name):
-            out.append(finding(
-                "github-node-runtime", ".github/workflows/pages.yml",
-                f"GitHub job {job_name} does not use the supported Node.js 24 runtime",
-                "run GitHub browser validation and assembly on Node.js 24",
-            ))
+    out.extend(audit_browser_runtime_jobs(
+        pages, ".github/workflows/pages.yml", "github",
+    ))
     for job_name in ("build-and-verify", "rebuild-for-comparison"):
         block = workflow_job(pages, job_name)
         require(block, "BUILD_PAGES_REUSE_VALIDATION=1", ".github/workflows/pages.yml",
@@ -966,31 +1000,9 @@ def audit_repo(
                 f"retain independent release assembly and comparison control: {token}")
     require(release, "release_gate.py --tier ship", ".github/workflows/release.yml",
             "release-shared-gate", out, "run the shared deterministic gate before packaging")
-    release_validation_job = workflow_job(release, "validate-and-scan")
-    release_browser_runtime_install = "pnpm install --frozen-lockfile --ignore-scripts"
-    if (
-        "working-directory: scripts/runtime" not in release_validation_job
-        or release_browser_runtime_install not in release_validation_job
-    ):
-        out.append(finding(
-            "release-browser-runtime-lock", ".github/workflows/release.yml",
-            "the protected release job does not install the nested pinned host-browser API",
-            "run pnpm from scripts/runtime with --frozen-lockfile before the shared ship gate",
-        ))
-    elif release_validation_job.index(release_browser_runtime_install) > release_validation_job.index(
-        "release_gate.py --tier ship"
-    ):
-        out.append(finding(
-            "release-browser-runtime-order", ".github/workflows/release.yml",
-            "the pinned host-browser API is installed after protected release validation",
-            "install the pinned browser API before the shared ship gate",
-        ))
-    if 'node-version: "24"' not in release_validation_job:
-        out.append(finding(
-            "release-node-runtime", ".github/workflows/release.yml",
-            "the protected release job does not use the supported Node.js 24 runtime",
-            "run protected release validation on Node.js 24",
-        ))
+    out.extend(audit_browser_runtime_jobs(
+        release, ".github/workflows/release.yml", "release",
+    ))
     require(release, "pull_materials.py --check --fetch-attempts", ".github/workflows/release.yml",
             "release-live-material-check", out,
             "require a retried, strict live material check before release packaging")

--- a/tests/validation/test_theme_runtime_contract.py
+++ b/tests/validation/test_theme_runtime_contract.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from scripts.skills import skill_renderer_runtime_audit as theme_runtime
 from scripts.validation import (
     cell_ui_runtime_audit as cell_runtime,
+    contribution_safety_audit as contribution_safety,
     helper_notebook_runtime_audit as helper_notebook,
     learner_flow_audit as learner_flow,
 )
@@ -109,21 +110,64 @@ class ThemeRuntimeContractTests(unittest.TestCase):
         self.assertIn('cd scripts/runtime && pnpm install --frozen-lockfile --ignore-scripts', core)
 
     def test_github_validation_jobs_install_the_pinned_browser_runtime(self) -> None:
-        install = (
-            "working-directory: scripts/runtime\n"
-            "        run: |\n"
-            "          corepack enable\n"
-            "          pnpm install --frozen-lockfile --ignore-scripts"
-        )
         for workflow in ("pages.yml", "release.yml"):
             with self.subTest(workflow=workflow):
                 source = (ROOT / ".github/workflows" / workflow).read_text(encoding="utf-8")
-                self.assertIn('node-version: "24"', source)
-                self.assertIn(install, source)
-                self.assertLess(
-                    source.index("pnpm install --frozen-lockfile --ignore-scripts"),
-                    source.index("release_gate.py --tier ship"),
-                )
+                browser_jobs = [
+                    (name, job)
+                    for name, job in contribution_safety.workflow_jobs(source)
+                    if any(
+                        consumer in job
+                        for consumer in contribution_safety.BROWSER_RUNTIME_CONSUMERS
+                    )
+                ]
+                self.assertTrue(browser_jobs)
+                for job_name, job in browser_jobs:
+                    with self.subTest(workflow=workflow, job=job_name):
+                        install_steps = [
+                            step for step in contribution_safety.workflow_steps(job)
+                            if "pnpm install --frozen-lockfile --ignore-scripts" in step
+                        ]
+                        self.assertEqual(len(install_steps), 1)
+                        self.assertIn("working-directory: scripts/runtime", install_steps[0])
+                        self.assertNotIn("--dir scripts/runtime", install_steps[0])
+                        self.assertIn('node-version: "24"', job)
+                        first_consumer = min(
+                            job.index(token)
+                            for token in contribution_safety.BROWSER_RUNTIME_CONSUMERS
+                            if token in job
+                        )
+                        install_position = (
+                            job.index(install_steps[0])
+                            + install_steps[0].index("pnpm install --frozen-lockfile --ignore-scripts")
+                        )
+                        self.assertLess(install_position, first_consumer)
+
+    def test_each_browser_backed_job_rejects_an_unscoped_runtime_install(self) -> None:
+        for workflow, prefix in (("pages.yml", "github"), ("release.yml", "release")):
+            source = (ROOT / ".github/workflows" / workflow).read_text(encoding="utf-8")
+            rel = f".github/workflows/{workflow}"
+            for job_name, job in contribution_safety.workflow_jobs(source):
+                if not any(
+                    consumer in job
+                    for consumer in contribution_safety.BROWSER_RUNTIME_CONSUMERS
+                ):
+                    continue
+                with self.subTest(workflow=workflow, job=job_name):
+                    mutated_job = job.replace(
+                        "working-directory: scripts/runtime",
+                        "working-directory: .",
+                        1,
+                    )
+                    self.assertNotEqual(mutated_job, job)
+                    mutated = source.replace(job, mutated_job, 1)
+                    codes = {
+                        item["code"]
+                        for item in contribution_safety.audit_browser_runtime_jobs(
+                            mutated, rel, prefix,
+                        )
+                    }
+                    self.assertIn(f"{prefix}-browser-runtime-lock", codes)
 
     def test_codeql_job_has_minimal_workflow_metadata_access(self) -> None:
         source = (ROOT / ".github/workflows/codeql.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Repair both failures from the first production Pages run. Browser-backed jobs now install the pinned runtime from its own directory, and source projection excludes its resolved artifact subtree so an in-checkout build cannot ingest itself.

## Issue link

Closes #11

## Current release target

- Course: bundle-wide static course publication
- Production: GitHub Pages from protected `main`
- Tooling: pinned host Python, Node.js, and Chromium
- Bundle scope: build and validation tooling

## Surfaces touched

- [ ] `web/`
- [ ] `i18n/`
- [x] `scripts/`
- [ ] `docs/`
- [ ] `materials/source governance`

## Blast radius checked

The validator discovers every workflow job that consumes the browser API and mutation-tests each one. The projector test uses an arbitrary in-tree artifact name, runs twice, and rejects any artifact root that contains the source root. English, Spanish, and Portuguese Pages assembly all ran.

## Validation evidence

- [x] PASS: Apple Container `doctor`
- [x] PASS: Apple Container `fast-gate` (63/63)
- [x] PASS: Apple Container `build-pages` on `956d078b7d2debb7e3798fb9b09ef0e3edbf773e` (ship 88/88; complete multilingual artifact)
- [x] PASS: focused standard-library unit and mutation tests

## Security and source impact

Workflow execution changes, but permissions, dependencies, secrets, external sources, licensing, and deployment authority do not. Runtime installation remains frozen and script-free. Artifact exclusion is derived from the caller's resolved output path, with no filename exception.

## External release follow-up

- [x] Threat and architecture assessment: NOT APPLICABLE; topology, authentication, trust boundaries, and data flow are unchanged.
- [ ] Authoritative vulnerability and secret scans: REQUIRED on this exact PR head.
- [x] Open-source and license review: NOT APPLICABLE; no dependency, source, or license change.
- [ ] Final-artifact SBOM, malware, and release evidence: REQUIRED through the exact merged `main` build.

## Human ownership

Vadim Kudlay owns the merge and release decision. The task author explicitly authorized owner merge and deployment. Codex inspected every changed line and ran the evidence above; host protections and exact-head checks remain authoritative.

## Release notes

Learner-facing: none.

Browser/runtime integration: Pages builds now use the intended pinned browser API.

Governance/process: ReACS now discovers every browser-backed workflow job instead of checking one named occurrence.

## Risk and rollback

The change affects Pages and release builders. Revert `956d078b7d2debb7e3798fb9b09ef0e3edbf773e` to restore the previous behavior.

## Out of scope

Course content and localized prose are byte-identical. No runtime endpoint, credential path, or deployment policy changed.
