### PR TITLE
Repair Pages renderer validation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -136,7 +136,7 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
       - name: Verify and exercise the exact Pages artifact
         run: |
-          python3 scripts/skills/skill_renderer_runtime_audit.py --site-root public --engine current
+          python3 scripts/skills/skill_renderer_runtime_audit.py --site-root public
           python3 scripts/validation/validation_report_audit.py --report public/gate.json --expect-sha "$GITHUB_SHA"
           python3 scripts/validation/branch_preview_manifest_audit.py --artifact-root public --manifest public/branches.json
           python3 scripts/validation/pages_artifact_integrity.py --root public --expect-sha "$GITHUB_SHA" --write-manifest public/pages-sha256.txt

--- a/scripts/runtime/html_document.py
+++ b/scripts/runtime/html_document.py
@@ -86,6 +86,32 @@ class _StrictRawTextParser(HTMLParser):
         line, column = self.getpos()
         return self.line_starts[line - 1] + column
 
+    def set_cdata_mode(self, elem: str, *, escapable: bool = False) -> None:
+        """Use the browser end-tag boundary on every supported Python release."""
+
+        del escapable
+        self.cdata_elem = elem.casefold()
+        self.interesting = re.compile(
+            rf"</{re.escape(self.cdata_elem)}(?=[\t\n\r\f />])",
+            re.IGNORECASE | re.ASCII,
+        )
+
+    def parse_endtag(self, index: int) -> int:
+        """Accept browser-recovered raw-text end tags consistently across Python versions."""
+
+        if self.cdata_elem == self.name:
+            close_end = _tag_end(self.rawdata, index)
+            tag = re.match(
+                r"</\s*([a-z][-.a-z0-9:_]*)(?=[\t\n\r\f />])",
+                self.rawdata[index:close_end],
+                re.IGNORECASE | re.ASCII,
+            )
+            if tag is not None and tag.group(1).casefold() == self.name:
+                self.handle_endtag(self.name)
+                self.clear_cdata_mode()
+                return close_end
+        return super().parse_endtag(index)
+
     @staticmethod
     def attributes(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
         return {str(key).casefold(): str(value or "") for key, value in attrs}

--- a/tests/validation/test_html_document.py
+++ b/tests/validation/test_html_document.py
@@ -54,10 +54,11 @@ class HtmlDocumentTests(unittest.TestCase):
                     self.assertEqual(browser, strict)
 
     def test_strict_projection_matches_browser_recovery_syntax(self) -> None:
-        for ending in ("</script foo=\"bar\">", "</script\t\n bar>"):
-            with self.subTest(ending=ending):
-                raw = f"<script>danger(){ending}<p>visible</p>"
-                self.assertEqual(raw_text_blocks(raw, "script"), raw_text_blocks_strict(raw, "script"))
+        for name in ("script", "style"):
+            for suffix in (' foo="bar">', "\t\n bar>"):
+                with self.subTest(name=name, suffix=suffix):
+                    raw = f"<{name}>danger()</{name}{suffix}<p>visible</p>"
+                    self.assertEqual(raw_text_blocks(raw, name), raw_text_blocks_strict(raw, name))
 
     def test_comments_and_longer_element_names_are_not_script_boundaries(self) -> None:
         raw = (

--- a/tests/validation/test_theme_runtime_contract.py
+++ b/tests/validation/test_theme_runtime_contract.py
@@ -91,12 +91,27 @@ class ThemeRuntimeContractTests(unittest.TestCase):
         self.assertIn('--site-root "$THEME_SITE_ROOT" --scan-root "$THEME_SCAN_ROOT"', job)
         self.assertNotIn('THEME_SITE_ROOT="public/$CI_COMMIT_REF_SLUG"', job)
 
-    def test_theme_job_arguments_match_the_runtime_cli(self) -> None:
-        job = core_job("theme_runtime", "human_review")
-        command = next(line.strip() for line in job.splitlines() if "skill_renderer_runtime_audit.py" in line)
-        tokens = shlex.split(command)
-        script = tokens.index("scripts/skills/skill_renderer_runtime_audit.py")
-        theme_runtime.build_parser().parse_args(tokens[script + 1 :])
+    def test_every_ci_renderer_command_matches_the_runtime_cli(self) -> None:
+        workflow_paths = {
+            *ROOT.glob(".github/workflows/*.yml"),
+            *ROOT.glob(".github/workflows/*.yaml"),
+            *ROOT.glob(".gitlab/**/*.yml"),
+            *ROOT.glob(".gitlab/**/*.yaml"),
+        }
+        commands: list[tuple[Path, int, list[str]]] = []
+        script_name = "scripts/skills/skill_renderer_runtime_audit.py"
+        for path in sorted(workflow_paths):
+            for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if script_name not in line or line.lstrip().startswith("#"):
+                    continue
+                tokens = shlex.split(line.strip())
+                script = tokens.index(script_name)
+                commands.append((path, line_number, tokens[script + 1 :]))
+
+        self.assertTrue(commands)
+        for path, line_number, arguments in commands:
+            with self.subTest(path=path.relative_to(ROOT), line=line_number):
+                theme_runtime.build_parser().parse_args(arguments)
 
     def test_report_producer_has_the_pinned_browser_runtime(self) -> None:
         core = (ROOT / ".gitlab/ci/core.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Repair the production Pages gate after main exposed an obsolete renderer flag. CI commands are now parsed by the renderer's real argument parser, and strict script/style recovery no longer varies with Python's `HTMLParser` implementation.

## Issue link

Closes #15

## Current release target

- Course: bundle-wide Pages artifact
- Production: GitHub Pages
- Tooling: pinned repository Python, Node.js, and Chromium in Apple Container and GitHub Actions
- Bundle scope: build and validation infrastructure

## Surfaces touched

- [ ] `web/`
- [ ] `i18n/`
- [x] `scripts/`
- [ ] `docs/`
- [ ] `materials/source governance`

## Blast radius checked

Discovered every renderer invocation under `.github/workflows/` and `.gitlab/`, parsed each with the production CLI, and exercised browser-compatible script and style end tags through both strict and tolerant projections.

## Validation evidence

- [x] PASS: Apple Container `doctor`
- [x] PASS: Apple Container `fast-gate` (63/63; 308 discovered tests)
- [x] PASS: Apple Container `build-pages` on `94ecb76a34c6c27d046330f0b6bfb9e6f5293244` (88/88; English, Spanish, and Portuguese)
- [x] PASS: focused renderer and HTML recovery suites

## Security and source impact

Workflow execution changes only by removing an argument the checked CLI rejects. No dependency, permission, secret, external-source, license, generated-asset, or deployment-authority change. Raw-text recovery remains fail-closed and now treats malformed browser end tags consistently.

## External release follow-up

- Threat and architecture assessment: NOT APPLICABLE; no topology, authentication, data-flow, or trust-boundary change.
- Authoritative vulnerability and secret scans: REQUIRED on the exact PR head before merge.
- Open-source and license review: NOT APPLICABLE; no dependency, source, material, or license change.
- Final-artifact SBOM, malware, and release evidence: COMPLETE locally for the signed candidate; GitHub Pages must reproduce it on exact main.

## Human ownership

Vadim Kudlay owns merge and release approval. Automated evidence does not claim human review.

## Release notes

Learner-facing: None.

Browser/runtime integration: Pages validation and raw-text projection are deterministic again.

Governance/process: CI renderer commands are checked against the real CLI without a workflow allowlist.

## Risk and rollback

Risk is limited to stricter raw-text boundary recognition and CI validation. Reverting `94ecb76a34c6c27d046330f0b6bfb9e6f5293244` restores the previous behavior, including the known Pages failure.

## Out of scope

No course prose, localization, dependencies, or threat model changed. Localized learner prose stayed byte-identical.
