### PR TITLE
Bound exhaustive Pages rendering

### DIFF
--- a/scripts/skills/skill_renderer_runtime_audit.py
+++ b/scripts/skills/skill_renderer_runtime_audit.py
@@ -12,14 +12,17 @@ or exemption list.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
+import signal
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 ROOT = Path(__file__).resolve().parents[2]
 MINIMUM_FULL_ARTIFACT_TIMEOUT_SECONDS = 600
@@ -42,6 +45,7 @@ const { chromium } = require('playwright-core');
 
 const root = process.env.SITE_ROOT || '/site';
 const htmlFiles = JSON.parse(fs.readFileSync(process.env.HTML_FILES || '/tmp/html-files.json', 'utf8'));
+const pageTimeoutMs = Number(process.env.PAGE_TIMEOUT_MS || '120000');
 let port = 0;
 const mime = {
   '.html':'text/html; charset=utf-8', '.js':'text/javascript; charset=utf-8',
@@ -104,9 +108,15 @@ server.on('upgrade', (request, socket) => {
 });
 
 async function inspect(browser, file) {
+  const startedAt = performance.now();
   let isSkill = /(?:^|\/)SKILL\.html$/.test(file);
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   const errors = [];
+  let pageTimedOut = false;
+  const pageTimer = setTimeout(() => {
+    pageTimedOut = true;
+    page.close().catch(() => {});
+  }, pageTimeoutMs);
   const ownedOrigin = `http://127.0.0.1:${port}`;
   const successfulOwned = new Set();
   let closing = false;
@@ -169,7 +179,9 @@ async function inspect(browser, file) {
       { timeout:10000 }
     );
     await page.waitForLoadState('domcontentloaded');
-    await page.waitForTimeout(500);
+    await page.evaluate(() => new Promise(resolve =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    ));
     isSkill = await page.evaluate(() =>
       /(?:^|\/)SKILL\.html$/.test(location.pathname) || !!document.getElementById('skill-meta')
     );
@@ -794,9 +806,11 @@ async function inspect(browser, file) {
   } catch (error) {
     errors.push(`navigation: ${error.message || String(error)}`);
   }
+  clearTimeout(pageTimer);
+  if (pageTimedOut) errors.push(`document audit exceeded ${pageTimeoutMs}ms`);
   closing = true;
-  await page.close();
-  return { file, errors: [...new Set(errors)] };
+  await page.close().catch(() => {});
+  return { file, durationMs: Math.round(performance.now() - startedAt), errors: [...new Set(errors)] };
 }
 
 (async () => {
@@ -816,14 +830,22 @@ async function inspect(browser, file) {
   let cursor = 0;
   let completed = 0;
   let nextProgressPercent = 10;
-  async function worker() {
+  async function worker(workerId) {
     while (cursor < htmlFiles.length) {
       const file = htmlFiles[cursor++];
-      const started = Date.now();
+      console.error(JSON.stringify({ event:'renderer-page-start', file, worker:workerId }));
+      const started = performance.now();
       const result = await inspect(browser, file);
+      console.error(JSON.stringify({
+        event:'renderer-page-finish',
+        file,
+        worker:workerId,
+        durationMs:result.durationMs,
+        findings:result.errors.length,
+      }));
       if (result.errors.length) findings.push(result);
       completed += 1;
-      const durationMs = Date.now() - started;
+      const durationMs = Math.round(performance.now() - started);
       const percent = Math.floor(completed * 100 / htmlFiles.length);
       if (durationMs >= 10000 || percent >= nextProgressPercent || completed === htmlFiles.length) {
         console.error(JSON.stringify({
@@ -838,7 +860,7 @@ async function inspect(browser, file) {
       }
     }
   }
-  await Promise.all(Array.from({ length: 4 }, worker));
+  await Promise.all(Array.from({ length:4 }, (_, index) => worker(index + 1)));
   await browser.close();
   server.close();
   console.log(JSON.stringify({ files:htmlFiles.length, findings }, null, 2));
@@ -849,6 +871,80 @@ async function inspect(browser, file) {
   process.exit(1);
 });
 """
+
+
+def _terminate_process(process: subprocess.Popen[str]) -> None:
+    """Stop the browser process tree after the whole-run deadline."""
+    if process.poll() is not None:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            if os.name == "posix":
+                os.killpg(process.pid, signal.SIGKILL)
+            else:
+                process.kill()
+        process.wait()
+
+
+def stream_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    timeout_seconds: int,
+    write: Callable[[str], object] = sys.stdout.write,
+) -> tuple[int, bool, list[str]]:
+    """Stream renderer evidence and retain active documents if the run stalls."""
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=os.name == "posix",
+    )
+    assert process.stdout is not None
+    active: set[str] = set()
+    active_lock = threading.Lock()
+
+    def pump() -> None:
+        for line in process.stdout:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                event = {}
+            if isinstance(event, dict):
+                file = event.get("file")
+                if isinstance(file, str):
+                    with active_lock:
+                        if event.get("event") == "renderer-page-start":
+                            active.add(file)
+                        elif event.get("event") == "renderer-page-finish":
+                            active.discard(file)
+            write(line)
+
+    reader = threading.Thread(target=pump, name="renderer-output", daemon=True)
+    reader.start()
+    timed_out = False
+    try:
+        returncode = process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _terminate_process(process)
+        returncode = process.returncode if process.returncode is not None else 1
+    reader.join(timeout=5)
+    process.stdout.close()
+    with active_lock:
+        stalled = sorted(active)
+    return returncode, timed_out, stalled
 
 
 def run(args: argparse.Namespace) -> int:
@@ -871,6 +967,9 @@ def run(args: argparse.Namespace) -> int:
     if not files:
         print(f"skill_renderer_runtime_audit: FAIL\n  - no HTML files under {site}")
         return 1
+    if args.timeout_seconds <= 0 or args.page_timeout_seconds <= 0:
+        print("skill_renderer_runtime_audit: FAIL\n  - timeout values must be positive")
+        return 1
     with tempfile.TemporaryDirectory(prefix="skill-renderer-audit-") as temp:
         temp_path = Path(temp)
         script = temp_path / "audit.js"
@@ -885,15 +984,15 @@ def run(args: argparse.Namespace) -> int:
                 "CHROME_BIN": "" if args.chrome_bin == "auto" else args.chrome_bin,
                 "SITE_ROOT": str(site),
                 "HTML_FILES": str(manifest),
+                "PAGE_TIMEOUT_MS": str(args.page_timeout_seconds * 1000),
             })
-            result = subprocess.run(
+            returncode, timed_out, stalled = stream_command(
                 command,
                 cwd=ROOT,
-                env=environment,
-                text=True,
-                timeout=args.timeout_seconds,
+                environment=environment,
+                timeout_seconds=args.timeout_seconds,
             )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        except FileNotFoundError as exc:
             print(
                 "skill_renderer_runtime_audit: FAIL\n"
                 f"  - {exc}\n"
@@ -901,8 +1000,15 @@ def run(args: argparse.Namespace) -> int:
                 f"{args.timeout_seconds}-second process budget"
             )
             return 1
-    print("skill_renderer_runtime_audit: " + ("OK" if result.returncode == 0 else "FAIL"))
-    return result.returncode
+        if timed_out:
+            active = ", ".join(stalled) if stalled else "(no document reported active)"
+            print(
+                "skill_renderer_runtime_audit: FAIL\n"
+                f"  - renderer exceeded {args.timeout_seconds}s; active documents: {active}"
+            )
+            return 1
+    print("skill_renderer_runtime_audit: " + ("OK" if returncode == 0 else "FAIL"))
+    return returncode
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -916,6 +1022,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=MINIMUM_FULL_ARTIFACT_TIMEOUT_SECONDS,
         help="whole-audit process budget; CI must not set less than the full-artifact minimum",
+    )
+    parser.add_argument(
+        "--page-timeout-seconds",
+        type=int,
+        default=120,
+        help="maximum time for one document before it is closed and reported",
     )
     return parser
 

--- a/tests/validation/test_theme_runtime_contract.py
+++ b/tests/validation/test_theme_runtime_contract.py
@@ -4,14 +4,11 @@
 """Standard-library contracts for browser-theme coverage and its CI triggers."""
 from __future__ import annotations
 
-import contextlib
-import io
 import shlex
+import sys
 import tempfile
 import unittest
 from pathlib import Path
-from types import SimpleNamespace
-from unittest import mock
 
 from scripts.skills import skill_renderer_runtime_audit as theme_runtime
 from scripts.validation import (
@@ -129,35 +126,67 @@ class ThemeRuntimeContractTests(unittest.TestCase):
         source = theme_runtime.RUNTIME_JS
         for token in (
             "event:'renderer-progress'",
+            "event:'renderer-page-start'",
+            "event:'renderer-page-finish'",
             "completed",
             "total:htmlFiles.length",
             "percent",
             "file",
             "durationMs",
+            "document audit exceeded ${pageTimeoutMs}ms",
+            "requestAnimationFrame(() => requestAnimationFrame(resolve))",
+            "performance.now()",
         ):
             with self.subTest(token=token):
                 self.assertIn(token, source)
+        self.assertNotIn("waitForTimeout(500)", source)
+        self.assertNotIn("htmlFiles.filter", source)
 
-        with tempfile.TemporaryDirectory() as directory:
-            site = Path(directory)
-            (site / "index.html").write_text("<!doctype html><title>fixture</title>", encoding="utf-8")
-            args = theme_runtime.build_parser().parse_args(["--site-root", str(site)])
-            with (
-                mock.patch.object(
-                    theme_runtime.subprocess,
-                    "run",
-                    return_value=SimpleNamespace(returncode=0),
-                ) as run_process,
-                contextlib.redirect_stdout(io.StringIO()),
-            ):
-                self.assertEqual(theme_runtime.run(args), 0)
-            call = run_process.call_args
-            self.assertNotIn("stdout", call.kwargs)
-            self.assertNotIn("stderr", call.kwargs)
-            self.assertEqual(
-                call.kwargs["timeout"],
-                theme_runtime.MINIMUM_FULL_ARTIFACT_TIMEOUT_SECONDS,
-            )
+    def test_streamed_runner_reports_the_active_document_on_timeout(self) -> None:
+        lines: list[str] = []
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import json,time;"
+                "print(json.dumps({'event':'renderer-page-start','file':'slow/SKILL.html'}),flush=True);"
+                "time.sleep(5)"
+            ),
+        ]
+        returncode, timed_out, active = theme_runtime.stream_command(
+            command,
+            cwd=ROOT,
+            environment={},
+            timeout_seconds=1,
+            write=lines.append,
+        )
+        self.assertNotEqual(returncode, 0)
+        self.assertTrue(timed_out)
+        self.assertEqual(active, ["slow/SKILL.html"])
+        self.assertIn('"event": "renderer-page-start"', "".join(lines))
+
+    def test_streamed_runner_clears_completed_documents(self) -> None:
+        lines: list[str] = []
+        command = [
+            sys.executable,
+            "-c",
+            (
+                "import json;"
+                "print(json.dumps({'event':'renderer-page-start','file':'done.html'}),flush=True);"
+                "print(json.dumps({'event':'renderer-page-finish','file':'done.html'}),flush=True)"
+            ),
+        ]
+        returncode, timed_out, active = theme_runtime.stream_command(
+            command,
+            cwd=ROOT,
+            environment={},
+            timeout_seconds=5,
+            write=lines.append,
+        )
+        self.assertEqual(returncode, 0)
+        self.assertFalse(timed_out)
+        self.assertEqual(active, [])
+        self.assertEqual(len(lines), 2)
 
     def test_report_producer_has_the_pinned_browser_runtime(self) -> None:
         core = (ROOT / ".gitlab/ci/core.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Keep exhaustive Pages rendering within its CI budget and make stalls attributable to a document.
The browser emits start/finish records, bounds each document, uses monotonic duration evidence, and
waits for two rendered frames instead of sleeping for a fixed 500 ms.

## Issue link

Closes #19

## Current release target

- Course: bundle-wide static Pages tree
- Production: GitHub Pages
- Tooling: pinned Python, Node, Playwright, and Chromium
- Bundle scope: bundle-wide

## Surfaces touched

- [ ] `web/`
- [ ] `i18n/`
- [x] `scripts/`
- [ ] `docs/`
- [ ] `materials/source governance`

## Blast radius checked

Checked the renderer CLI, every GitHub and GitLab caller, the PR-only generated-site browser audit
from main, all 365 generated HTML documents, process cleanup, active-document diagnostics, theme
coverage, generated source explorers, and the multilingual Pages build. Discovery and its
no-exemption contract are unchanged.

## Validation evidence

- [x] PASS: verified GitHub head `5782ebd`, parent `6e4d53a`, both DCO trailers
- [x] PASS: Apple Container `doctor`
- [x] PASS: Apple Container `fast-gate` (63/63)
- [x] PASS: Apple Container `build-pages` at `5782ebd` (88/88; English, Spanish, Portuguese)
- [x] PASS: exact built-tree renderer (365/365; zero findings)
- [x] PASS: focused runtime contract tests (43/43)
- [x] PASS: forced-timeout and completed-process mutation tests

## Security and source impact

No dependency, permission, secret, external-source, license, or release-authority change. Timeout
cleanup terminates the renderer process group instead of leaving browser descendants.

## External release follow-up

- Threat and architecture assessment: NOT APPLICABLE
- Authoritative vulnerability and secret scans: NOT APPLICABLE
- Open-source and license review: NOT APPLICABLE
- Final-artifact SBOM, malware, and release evidence: NOT APPLICABLE

## Human ownership

Vadim Kudlay owns complete-diff review, merge, and release approval. Automated evidence does not
replace that host-enforced decision.

## Release notes

Learner-facing: none.

Browser/runtime integration: exhaustive renderer progress, per-document limits, and bounded failure
diagnostics.

Governance/process: production Pages validation remains fail-closed.

## Risk and rollback

Risk is premature page inspection. Two animation frames replace the fixed delay, while existing
explicit waits still guard redirects, exports, SVGs, and the Pyodide runtime. Revert `5782ebd` to
restore the prior runner.

## Out of scope

Course content, locale prose, dependency versions, and workflow authority are unchanged.
