### PR TITLE
Reject invalid pull requests before expensive Pages checks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,12 +28,44 @@ jobs:
           persist-credentials: false
       - name: Reject oversized proposed source before expensive analysis
         run: python3 scripts/validation/pages_artifact_integrity.py --source-root .
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
+      - name: Pull request submission contract
+        if: github.event_name == 'pull_request'
+        env:
+          CONTRIBUTION_BODY: ${{ github.event.pull_request.body }}
+        run: python3 scripts/validation/contribution_safety_audit.py --submission-env CONTRIBUTION_BODY
+      - name: Pull request commit signoff
+        if: github.event_name == 'pull_request'
+        env:
+          DCO_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/validation/contribution_safety_audit.py --commit-range "$DCO_RANGE"
+      - name: Pull request contributor-local boundary
+        if: github.event_name == 'pull_request'
+        env:
+          PATH_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/validation/local_path_leak_audit.py --commit-range "$PATH_RANGE"
+      - name: Pull request sensitive metadata boundary
+        if: github.event_name == 'pull_request'
+        env:
+          SENSITIVE_TITLE: ${{ github.event.pull_request.title }}
+          SENSITIVE_BODY: ${{ github.event.pull_request.body }}
+          SENSITIVE_REF: ${{ github.event.pull_request.head.ref }}
+        run: python3 scripts/validation/sensitive_content_audit.py --submission-env SENSITIVE_TITLE --submission-env SENSITIVE_BODY --submission-env SENSITIVE_REF
+      - name: Pull request sensitive history boundary
+        if: github.event_name == 'pull_request'
+        env:
+          SENSITIVE_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/validation/sensitive_content_audit.py --commit-range "$SENSITIVE_RANGE"
+      - name: Pull request external release follow-up reminder
+        if: github.event_name == 'pull_request'
+        env:
+          RELEASE_CHANGE_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+        run: python3 scripts/validation/release_change_reminder.py --commit-range "$RELEASE_CHANGE_RANGE" --report docs/validation/release-change-reminder.json
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
       - name: Verify the no-fetch Pages dependency boundary
         run: BUILD_PAGES_PULL_MATERIALS=0 BUILD_PAGES_REUSE_VALIDATION=1 BUILD_PAGES_PREFLIGHT_ONLY=1 bash scripts/build/build_pages.sh
       - name: Install the pinned host-browser API
@@ -104,38 +136,6 @@ jobs:
             --extract-to "$RUNNER_TEMP/pages-action-canary-extracted"
           test -f "$RUNNER_TEMP/pages-action-canary-extracted/.course-review-marker"
           test -f "$RUNNER_TEMP/pages-action-canary-extracted/.github/course-review-marker"
-      - name: Pull request submission contract
-        if: github.event_name == 'pull_request'
-        env:
-          CONTRIBUTION_BODY: ${{ github.event.pull_request.body }}
-        run: python3 scripts/validation/contribution_safety_audit.py --submission-env CONTRIBUTION_BODY
-      - name: Pull request commit signoff
-        if: github.event_name == 'pull_request'
-        env:
-          DCO_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
-        run: python3 scripts/validation/contribution_safety_audit.py --commit-range "$DCO_RANGE"
-      - name: Pull request contributor-local boundary
-        if: github.event_name == 'pull_request'
-        env:
-          PATH_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
-        run: python3 scripts/validation/local_path_leak_audit.py --commit-range "$PATH_RANGE"
-      - name: Pull request sensitive metadata boundary
-        if: github.event_name == 'pull_request'
-        env:
-          SENSITIVE_TITLE: ${{ github.event.pull_request.title }}
-          SENSITIVE_BODY: ${{ github.event.pull_request.body }}
-          SENSITIVE_REF: ${{ github.event.pull_request.head.ref }}
-        run: python3 scripts/validation/sensitive_content_audit.py --submission-env SENSITIVE_TITLE --submission-env SENSITIVE_BODY --submission-env SENSITIVE_REF
-      - name: Pull request sensitive history boundary
-        if: github.event_name == 'pull_request'
-        env:
-          SENSITIVE_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
-        run: python3 scripts/validation/sensitive_content_audit.py --commit-range "$SENSITIVE_RANGE"
-      - name: Pull request external release follow-up reminder
-        if: github.event_name == 'pull_request'
-        env:
-          RELEASE_CHANGE_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
-        run: python3 scripts/validation/release_change_reminder.py --commit-range "$RELEASE_CHANGE_RANGE" --report docs/validation/release-change-reminder.json
       - name: Materials drift check (advisory; complains on drift, never blocks the deploy)
         continue-on-error: true
         run: python3 scripts/materials/pull_materials.py --check --fetch-attempts 4 --retry-backoff 2 --host-delay 3

--- a/scripts/validation/contribution_safety_audit.py
+++ b/scripts/validation/contribution_safety_audit.py
@@ -827,6 +827,26 @@ def audit_repo(
         pages, ".github/workflows/pages.yml", "github",
     ))
     test_block = workflow_job(pages, "test")
+    fail_fast_steps = (
+        "Pull request submission contract",
+        "Pull request commit signoff",
+        "Pull request contributor-local boundary",
+        "Pull request sensitive metadata boundary",
+        "Pull request sensitive history boundary",
+        "Pull request external release follow-up reminder",
+    )
+    expensive_boundary = test_block.find("actions/setup-node@")
+    fail_fast_offsets = [test_block.find(f"- name: {name}") for name in fail_fast_steps]
+    if (
+        expensive_boundary < 0
+        or any(offset < 0 for offset in fail_fast_offsets)
+        or max(fail_fast_offsets, default=expensive_boundary) >= expensive_boundary
+    ):
+        out.append(finding(
+            "github-pr-fail-fast-order", ".github/workflows/pages.yml",
+            "cheap pull-request integrity checks can run after dependency or browser work",
+            "run submission, DCO, local-path, sensitive-content, and release-reminder checks before setup-node",
+        ))
     pr_browser_steps = [
         step for step in workflow_steps(test_block)
         if "skill_renderer_runtime_audit.py" in step
@@ -1798,6 +1818,15 @@ def self_test() -> list[str]:
             ("prose-review-judgment", "docs/course-prose-style.md", "Automated signals identify passages", "Scores decide every rewrite"),
             ("prose-locale-ownership", "docs/course-prose-style.md", "Locale ownership", "Translation rewrite"),
             ("github-pr-trigger", ".github/workflows/pages.yml", "  pull_request:\n", "  # pull_request removed\n"),
+            (
+                "github-pr-fail-fast-order",
+                ".github/workflows/pages.yml",
+                "      - name: Pull request submission contract\n",
+                "      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0\n"
+                "        with:\n"
+                "          node-version: \"24\"\n"
+                "      - name: Pull request submission contract\n",
+            ),
             ("pages-fresh-validation-report", "scripts/build/build_pages.sh", 'python3 "$T1/scripts/validation/validate_bundle.py" --scope ship', 'python3 "$T1/scripts/validation/missing_bundle_gate.py" --scope ship'),
             ("pages-report-reuse-audit", "scripts/build/build_pages.sh", 'validation_report_audit.py"', 'missing_report_audit.py"'),
             ("pages-report-reuse-immutable", "scripts/build/build_pages.sh", 'if [ "$REUSE_VALIDATION" = "1" ] && [ "$PULL_MATERIALS" != "0" ]; then', 'if [ "$REUSE_VALIDATION" = "2" ] && [ "$PULL_MATERIALS" != "0" ]; then'),


### PR DESCRIPTION
## Summary

Run inexpensive pull-request integrity checks before dependency, build, and browser work.

## Issue link

Closes #27

## Current release target

- Course: bundle-wide GitHub Pages validation
- Production: `https://nvdli.github.io/NemoClawDLI/`
- Tooling: GitHub-hosted runner with pinned Actions
- Bundle scope: bundle-wide

## Surfaces touched

- [x] `.github/workflows/pages.yml`
- [x] `scripts/validation/contribution_safety_audit.py`

## Blast radius checked

Checked the complete Pages test job and contribution-safety mutation suite. Submission, DCO, local-path, sensitive-content, and release-reminder checks now run before Node setup. Main's prohibition on `configure-pages` remains intact.

## Validation evidence

- [x] Actionlint — PASS
- [x] Contribution-safety self-test and repository audit — PASS
- [x] Apple Container `fast-gate` — PASS, 63/63
- [x] Apple Container `build-pages` — PASS, 88/88 and all locale builds

## Security and source impact

No authority, dependency, secret, license, source, or learner-runtime change. The existing checks keep their commands and fail-closed behavior; only their order changes.

## External release follow-up

- Threat/architecture, vulnerability, license, and SBOM follow-up: NOT APPLICABLE; no shipped code, dependency, source, or trust boundary changes.

## Human ownership

Vadim Kudlay owns merge and release approval. Review should confirm that every fast rejection runs before `setup-node` and that the mutation detects late ordering.

## Release notes

- Learner-facing: none.
- Browser/runtime: none.
- Governance: reject invalid submissions before expensive Pages validation.

## Risk and rollback

Risk is limited to workflow ordering. Revert `8cfcbb3e59e078f9384a4af5e437fd6ca02ef834` to restore the prior order.

## Out of scope

Pages host initialization was resolved separately by #26. Learner prose and locale overlays remain byte-identical.
