### PR TITLE
Keep Pages host setup outside builders

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -185,7 +185,6 @@ jobs:
           python3 scripts/validation/runtime_integration_browser_audit.py --site-root public --timeout-ms 180000
           python3 scripts/validation/branch_preview_runtime_audit.py --site-root public
           python3 scripts/validation/pages_artifact_integrity.py --root public --expect-sha "$GITHUB_SHA" --check-manifest public/pages-sha256.txt
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Archive every reviewed Pages file
         run: |
           # upload-pages-artifact always omits .github, which is part of this reviewed site.

--- a/scripts/validation/contribution_safety_audit.py
+++ b/scripts/validation/contribution_safety_audit.py
@@ -797,6 +797,12 @@ def audit_repo(
         out.append(finding("github-global-permissions", ".github/workflows/pages.yml",
                            "workflow-level permissions are not read-only",
                            "keep contents: read globally and grant Pages writes only to the deploy job"))
+    if action_steps(pages, "actions/configure-pages"):
+        out.append(finding(
+            "github-pages-host-configuration", ".github/workflows/pages.yml",
+            "source-controlled CI can query, enable, or reconfigure the Pages host",
+            "initialize Pages once through an authorized repository owner and keep builders read-only",
+        ))
     production_condition = "if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'"
     for job_name in ("build-and-verify", "rebuild-for-comparison", "compare-builds", "attest-provenance", "deploy"):
         block = workflow_job(pages, job_name)
@@ -1871,6 +1877,7 @@ def self_test() -> list[str]:
             ("github-pages-build-dependency-isolation", ".github/workflows/pages.yml", "      - name: Build the client-side static site\n", "      - name: Build the client-side static site\n        run: npm ci\n"),
             ("github-pages-signing-source-execution", ".github/workflows/pages.yml", "    needs: compare-builds\n    runs-on: ubuntu-latest\n", "    needs: compare-builds\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@bad\n"),
             ("github-pages-deploy-source-execution", ".github/workflows/pages.yml", "    steps:\n      - id: deploy\n", "    steps:\n      - run: python3 scripts/steal_token.py\n      - id: deploy\n"),
+            ("github-pages-host-configuration", ".github/workflows/pages.yml", "    steps:\n      - id: deploy\n", "    steps:\n      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d\n      - id: deploy\n"),
             ("github-source-resource-preflight", ".github/workflows/pages.yml", "pages_artifact_integrity.py --source-root .", "pages_artifact_integrity.py --help"),
             ("release-source-resource-preflight", ".github/workflows/release.yml", "pages_artifact_integrity.py --source-root .", "pages_artifact_integrity.py --help"),
             ("release-live-material-check", ".github/workflows/release.yml", "pull_materials.py --check --fetch-attempts", "pull_materials.py --list --fetch-attempts"),


### PR DESCRIPTION
## Summary

Keep the Pages builder read-only by removing repository-host configuration from the build job. Add a mutation-tested repository guard so `actions/configure-pages` cannot return to source-controlled CI.

## Issue link

Closes #25

## Current release target

- Course: unchanged static browser course
- Production: GitHub Pages
- Tooling: unchanged pinned Python, Node.js, and Chromium
- Bundle scope: GitHub workflow and contribution validator

## Surfaces touched

- [ ] `web/`
- [ ] `i18n/`
- [x] `scripts/`
- [ ] `docs/`
- [ ] `materials/source governance`

## Blast radius checked

Checked the global read-only workflow permission, job-level Pages permissions, build, provenance, deploy ordering, protected environment boundary, complete generated-site audit, and the contribution-safety mutation matrix. Pages was initialized once through repository-owner authority; no host identifier or credential enters the repository.

## Validation evidence

- PASS: Apple Container `doctor`
- PASS: Apple Container `fast-gate` (63/63)
- PASS: Apple Container `build-pages` (88/88; English, Spanish, and Portuguese)
- PASS: generated artifact navigation and link audits
- PASS: `git diff --check`

## Security and source impact

The builder loses a host-configuration action and retains only global `contents: read`. The deploy job remains the only job with `pages: write` and `id-token: write`. No dependency, secret, learner content, release artifact, or external source changes.

## External release follow-up

- Threat and architecture assessment: NOT APPLICABLE; authority is reduced to the documented boundary
- Authoritative vulnerability and secret scans: REQUIRED in exact-head GitHub CI
- Open-source and license review: NOT APPLICABLE; no source or dependency change
- Final-artifact SBOM, malware, and release evidence: NOT APPLICABLE; artifact inputs are unchanged

## Human ownership

Vadim Kudlay owns complete-diff review, merge authority, and the production environment decision. Agent validation is evidence only and does not supply independent approval.

## Release notes

Learner-facing: none.

Browser/runtime integration: none.

Governance/process: Pages host activation stays outside read-only builders.

## Risk and rollback

A disabled or deleted Pages host will fail deployment instead of allowing a builder to restore it. Reverting this commit restores the prior workflow, but also restores the broader builder authority and should require an explicit security decision.

## Out of scope

No course content, localization, dependency, runtime, or environment-review policy changes. The production reviewer requirement remains intact.
