### PR TITLE
Route GitHub Pages model calls through the supported relay

### DIFF
--- a/scripts/runtime/test_page_runtime.js
+++ b/scripts/runtime/test_page_runtime.js
@@ -331,8 +331,8 @@ function findChrome() {
     } catch (e) { console.log('ACCESS_COOKIE: skipped (' + e.message + ')'); }
   }
 
-  // The web course is remote-service-only: browser pages call integrate.api.nvidia.com directly with the learner's nvapi key.
-  // The harness mirrors that path.
+  // The web course is remote-service-only. Published course origins and local previews use the
+  // bounded browser relay for the default endpoint; custom endpoints remain direct.
   await page.addInitScript(({ apiKey, apiUrl, useIframeProxy }) => {
     try {
       const defaultUrl = "https://integrate.api.nvidia.com/v1";
@@ -425,7 +425,20 @@ function findChrome() {
         } catch (_) {}
       }
       const status = await panel.locator('.course-artifact-actions [role="status"]').innerText();
-      const result = { prompt:index + 1, model, validated, rejections:rejections.length, chatErrors, sourceChars, controlCount, changed, status, lastAnswer };
+      const result = {
+        prompt:index + 1,
+        model,
+        validated,
+        rejections:rejections.length,
+        chatErrors,
+        pageErrors:[...errors],
+        resourceErrors:[...resourceErrors],
+        sourceChars,
+        controlCount,
+        changed,
+        status,
+        lastAnswer,
+      };
       results.push(result);
       if (!validated || !sourceChars || !controlCount || !changed || chatErrors.length || /error|rejected|erro/i.test(status)) {
         console.log('COURSE_ASSISTANT_ARTIFACTS:', JSON.stringify(results, null, 2));

--- a/scripts/security/audit_iframe_proxy_opt_in.py
+++ b/scripts/security/audit_iframe_proxy_opt_in.py
@@ -5,8 +5,9 @@
 """Audit that browser model-relay routing is explicit, bounded, and documented.
 
 This is a narrow source audit. It does not contact the hosted service; it checks
-that the DLI CDN default is origin-bound, every other course origin stays direct,
-the learner can override that default, and custom endpoints never enter the relay.
+that the published course defaults are origin-bound, every other course origin
+stays direct, the learner can override that default, and custom endpoints never
+enter the relay.
 """
 from __future__ import annotations
 
@@ -22,6 +23,10 @@ ROOT = Path(__file__).resolve().parents[2]
 BUILD_PROXY = "https://nvidia-api-cors-proxy.experiments.courses.nvidia.com"
 OPENCLAW_PROXY = "https://openclaw-cors-proxy.experiments.courses.nvidia.com"
 LEGACY_BILLING_HEADER = "X-BILLING-" + "SOURCE"
+EXPECTED_MODEL_RELAY_DEFAULT_ORIGINS = [
+    "https://cdn.dli.learn.nvidia.com",
+    "https://nvdli.github.io",
+]
 
 CHECKS = [
     (
@@ -37,9 +42,9 @@ CHECKS = [
         [],
     ),
     (
-        "runtime binds the relay default to the DLI CDN and preserves explicit overrides",
+        "runtime binds the relay default to the published course origins and preserves explicit overrides",
         "web/nemoclaw/scripts/_shared.js",
-        ["https://integrate.api.nvidia.com/v1", 'const IFRAME_PROXY_URL = "https://nvidia-api-cors-proxy.experiments.courses.nvidia.com/v1"', 'const MODEL_RELAY_DEFAULT_ORIGINS = new Set(["https://cdn.dli.learn.nvidia.com"])', "defaultIframeProxyModeForLocation", 'stored === "0"', 'localStorage.setItem(IFRAME_PROXY_OPT_IN_KEY, enabled ? "1" : "0")', "iframe_proxy", "lms_proxy", "iframeProxy: false", "iframeProxy: true"],
+        ["https://integrate.api.nvidia.com/v1", 'const IFRAME_PROXY_URL = "https://nvidia-api-cors-proxy.experiments.courses.nvidia.com/v1"', "MODEL_RELAY_DEFAULT_ORIGINS", "https://cdn.dli.learn.nvidia.com", "https://nvdli.github.io", "defaultIframeProxyModeForLocation", 'stored === "0"', 'localStorage.setItem(IFRAME_PROXY_OPT_IN_KEY, enabled ? "1" : "0")', "iframe_proxy", "lms_proxy", "iframeProxy: false", "iframeProxy: true"],
         [r'const\s+DIRECT_URL\s*=\s*"https://nvidia-api-cors-proxy'],
     ),
     (
@@ -73,7 +78,7 @@ CHECKS = [
     (
         "reference implementation findings are documented",
         "scripts/security/iframe_proxy_worker_findings.md",
-        ["compact teaching references", "X-BILLING-INVOKE-ORIGIN", "ALLOWED_ORIGINS", "deployment-owner review", "exact `https://cdn.dli.learn.nvidia.com` origin", "explicit direct override"],
+        ["compact teaching references", "X-BILLING-INVOKE-ORIGIN", "ALLOWED_ORIGINS", "deployment-owner review", "exact published course origins", "explicit direct override"],
         [],
     ),
     (
@@ -218,8 +223,11 @@ def source_findings(
         shared = shared.replace(old, new, 1)
     match = re.search(r"MODEL_RELAY_DEFAULT_ORIGINS\s*=\s*new Set\(\[([^]]*)\]\)", shared)
     origins = re.findall(r'["\'](https?://[^"\']+)["\']', match.group(1)) if match else []
-    if origins != ["https://cdn.dli.learn.nvidia.com"]:
-        failures.append("FAIL model relay default origin allowlist must contain only https://cdn.dli.learn.nvidia.com")
+    if origins != EXPECTED_MODEL_RELAY_DEFAULT_ORIGINS:
+        failures.append(
+            "FAIL model relay default origin allowlist must contain only "
+            + ", ".join(EXPECTED_MODEL_RELAY_DEFAULT_ORIGINS)
+        )
     if scan_retired:
         tracked = subprocess.run(
             ["git", "-C", str(root), "ls-files", "-z"],
@@ -246,7 +254,8 @@ def self_test() -> list[str]:
         ("saved embedding endpoint", "web/nemoclaw/scripts/_shared.js", "export function setEmbeddingApiBaseUrl(raw)", "function removedEmbeddingSetter(raw)"),
         ("explicit setup field", "web/nemoclaw/scripts/_keypanel.js", '<input type="url" class="model-api-base-url"', '<input type="url" class="removed-endpoint-field"'),
         ("custom endpoint bypasses iframe relay", "web/nemoclaw/scripts/_keypanel.js", "setIframeProxyMode(defaultEndpoint &&", "setIframeProxyMode(true &&"),
-        ("bounded CDN relay default", "web/nemoclaw/scripts/_shared.js", 'new Set(["https://cdn.dli.learn.nvidia.com"])', 'new Set(["https://cdn.dli.learn.nvidia.com", "https://example.com"])'),
+        ("bounded CDN relay default", "web/nemoclaw/scripts/_shared.js", '"https://cdn.dli.learn.nvidia.com"', '"https://example.com"'),
+        ("bounded Pages relay default", "web/nemoclaw/scripts/_shared.js", '"https://nvdli.github.io"', '"https://nvdli.github.io.example.invalid"'),
         ("explicit direct override", "web/nemoclaw/scripts/_shared.js", 'stored === "0"', 'stored === "disabled"'),
         ("custom endpoint omits NVIDIA attribution", "web/nemoclaw/scripts/_shared.js", "if (billingAttributionEnabled(cfg.url))", "if (true)"),
         ("credential destination warning", "web/nemoclaw/index.html", "selected endpoint", "configured service"),

--- a/scripts/security/codeql-vendor-dispositions.json
+++ b/scripts/security/codeql-vendor-dispositions.json
@@ -87,7 +87,7 @@
         }
       ],
       "artifact": "web/nemoclaw/scripts/_shared.js",
-      "artifact_sha256": "88bc5ea198ac3ca5b61c2eb5ee3da39d223fc6dc1b86932e1ff5e82ecc9d5d8d",
+      "artifact_sha256": "6c70efd088f143f9cabd920b0e2867c4bbe86703a9ad81965439156b6c815af2",
       "decision": "explicit-user-tab-credential-boundary",
       "owner": "course-maintainers",
       "expires": "2026-10-24",
@@ -108,7 +108,7 @@
         "ed7637f0d5001db656769e4162f3e4f98d83b6905f9f9ae0017da02d78fbefff"
       ],
       "artifact": "scripts/runtime/test_page_runtime.js",
-      "artifact_sha256": "6db63c91027474ab9fc950fd6c78fb35fbf938e4b156927997644b6ac9ca1e51",
+      "artifact_sha256": "0a841528399b81755e6fa539b6b7b21a8a2ac3a02f078a24e4edf5f8c49c3916",
       "decision": "explicit-user-tab-credential-boundary",
       "owner": "course-maintainers",
       "expires": "2026-10-24",

--- a/scripts/security/iframe_proxy_worker_findings.md
+++ b/scripts/security/iframe_proxy_worker_findings.md
@@ -6,7 +6,7 @@ Lambda, CloudFront, and generic infrastructure projection. Neither is evidence o
 
 Properties retained in both representations:
 
-- The course client defaults to the model relay only on the exact `https://cdn.dli.learn.nvidia.com` origin, where the direct upstream CORS response is not reliable. A stored or query-string explicit direct override can force direct mode, all other course origins remain direct by default, and custom endpoints never enter this relay.
+- The course client defaults to the model relay only on the exact published course origins, `https://cdn.dli.learn.nvidia.com` and `https://nvdli.github.io`, where the direct upstream CORS response is not reliable. A stored or query-string explicit direct override can force direct mode, all other origins remain direct by default, and custom endpoints never enter this relay.
 - `cors-proxy-worker-build.js` reflects the request `Origin` into `Access-Control-Allow-Origin`. That keeps LMS/static iframe execution working, but it is broad. The hosted deployment must own and review its exact `ALLOWED_ORIGINS` policy.
 - `cors-proxy-worker-build.js` forwards caller headers to `integrate.api.nvidia.com`. Keep `X-BILLING-INVOKE-ORIGIN` allowed and forwarded because direct and proxy paths both use it for tracking.
 - The launchable relay restricts upstream hosts to the two supported Brev host families, binds each

--- a/scripts/validation/learner_flow_runtime_audit.py
+++ b/scripts/validation/learner_flow_runtime_audit.py
@@ -139,9 +139,12 @@ async function waitText(locator, pattern) {
     return {
       orphans:canvas.helperMenuOrphans(),
       cdnDefault:shared.defaultIframeProxyModeForLocation('https://cdn.dli.learn.nvidia.com/course-static/nemoclaw/'),
+      pagesDefault:shared.defaultIframeProxyModeForLocation('https://nvdli.github.io/NemoClawDLI/nemoclaw/'),
       localFile:shared.defaultIframeProxyModeForLocation('file:course-preview.html'),
       cdnHttp:shared.defaultIframeProxyModeForLocation('http://cdn.dli.learn.nvidia.com/course-static/nemoclaw/'),
       siblingHost:shared.defaultIframeProxyModeForLocation('https://cdn.dli.learn.nvidia.com.example.invalid/'),
+      pagesHttp:shared.defaultIframeProxyModeForLocation('http://nvdli.github.io/NemoClawDLI/nemoclaw/'),
+      pagesSibling:shared.defaultIframeProxyModeForLocation('https://nvdli.github.io.example.invalid/NemoClawDLI/'),
       unrelatedHost:shared.defaultIframeProxyModeForLocation('https://example.com/'),
       localDefault,
       explicitRelay,
@@ -149,7 +152,12 @@ async function waitText(locator, pattern) {
     };
   });
   if (runtimeRegistryContract.orphans.length) throw new Error(`helper registry has uncategorized entries: ${JSON.stringify(runtimeRegistryContract.orphans)}`);
-  if (!runtimeRegistryContract.cdnDefault || !runtimeRegistryContract.localFile || runtimeRegistryContract.cdnHttp || runtimeRegistryContract.siblingHost || runtimeRegistryContract.unrelatedHost) throw new Error(`model relay default escaped the CDN and local-preview boundary: ${JSON.stringify(runtimeRegistryContract)}`);
+  if (!runtimeRegistryContract.cdnDefault || !runtimeRegistryContract.pagesDefault || !runtimeRegistryContract.localFile ||
+      runtimeRegistryContract.cdnHttp || runtimeRegistryContract.siblingHost ||
+      runtimeRegistryContract.pagesHttp || runtimeRegistryContract.pagesSibling ||
+      runtimeRegistryContract.unrelatedHost) {
+    throw new Error(`model relay default escaped the published-origin and local-preview boundary: ${JSON.stringify(runtimeRegistryContract)}`);
+  }
   if (runtimeRegistryContract.localDefault || !runtimeRegistryContract.explicitRelay || runtimeRegistryContract.explicitDirect) throw new Error(`model relay override is not deterministic: ${JSON.stringify(runtimeRegistryContract)}`);
 
   const depthSelect = page.locator('.learning-depth-select');

--- a/tests/runtime/test_model_routing.mjs
+++ b/tests/runtime/test_model_routing.mjs
@@ -14,13 +14,21 @@ const {
   setModelApiBaseUrl,
 } = sharedRuntime;
 
-test('the model relay default covers the exact DLI CDN origin and local file previews', () => {
-  assert.equal(defaultIframeProxyModeForLocation('https://cdn.dli.learn.nvidia.com/course-static/nemoclaw/'), true);
-  assert.equal(defaultIframeProxyModeForLocation('file:course-preview.html'), true);
-  assert.equal(defaultIframeProxyModeForLocation('http://cdn.dli.learn.nvidia.com/course-static/nemoclaw/'), false);
-  assert.equal(defaultIframeProxyModeForLocation('https://cdn.dli.learn.nvidia.com.example.invalid/'), false);
-  assert.equal(defaultIframeProxyModeForLocation('https://example.com/'), false);
-  assert.equal(defaultIframeProxyModeForLocation('data:text/html,course'), false);
+test('the model relay default covers only the exact published course origins and local files', () => {
+  const cases = [
+    ['https://cdn.dli.learn.nvidia.com/course-static/nemoclaw/', true],
+    ['https://nvdli.github.io/NemoClawDLI/nemoclaw/', true],
+    ['file:course-preview.html', true],
+    ['http://cdn.dli.learn.nvidia.com/course-static/nemoclaw/', false],
+    ['https://cdn.dli.learn.nvidia.com.example.invalid/', false],
+    ['http://nvdli.github.io/NemoClawDLI/nemoclaw/', false],
+    ['https://nvdli.github.io.example.invalid/NemoClawDLI/', false],
+    ['https://example.com/', false],
+    ['data:text/html,course', false],
+  ];
+  for (const [location, expected] of cases) {
+    assert.equal(defaultIframeProxyModeForLocation(location), expected, location);
+  }
 });
 
 test('a failed model call from a local file explains the supported preview paths', async () => {

--- a/web/nemoclaw/scripts/_shared.js
+++ b/web/nemoclaw/scripts/_shared.js
@@ -3,14 +3,17 @@
 
 // ─── Shared runtime for the nemoclaw web course (frontend track) ─────────────
 
-// Remote-service-only. Direct calls use the learner key. The published DLI CDN uses the
+// Remote-service-only. Direct calls use the learner key. The published course origins use the
 // bounded NVIDIA DLI relay by default because the upstream browser CORS response is not stable.
 // Local file previews use the same relay; other origins stay direct unless the learner enables it.
 
 export const DEFAULT_MODEL_API_BASE_URL = "https://integrate.api.nvidia.com/v1";
 const IFRAME_PROXY_URL = "https://nvidia-api-cors-proxy.experiments.courses.nvidia.com/v1";
 const IFRAME_PROXY_OPT_IN_KEY = "nemoclaw_iframe_proxy_opt_in";
-const MODEL_RELAY_DEFAULT_ORIGINS = new Set(["https://cdn.dli.learn.nvidia.com"]);
+const MODEL_RELAY_DEFAULT_ORIGINS = new Set([
+  "https://cdn.dli.learn.nvidia.com",
+  "https://nvdli.github.io",
+]);
 const MODEL_API_BASE_URL_KEY = "nemoclaw_model_api_base_url_v1";
 const MODEL_ID_KEY = "nemoclaw_model_id_v1";
 const EMBEDDING_API_BASE_URL_KEY = "nemoclaw_embedding_api_base_url_v1";
@@ -226,9 +229,9 @@ export async function getConfig() {
   /* @doc <code>helpers.getConfig()</code> ::
        Returns the active chat config <code>{ mode, url, model, needsKey, iframeProxy }</code>.
        A presenter can save one compatible chat endpoint and model on the course home page.
-       Embeddings retain their own route. The DLI CDN and local file previews default to the
-       bounded NVIDIA DLI relay; other origins stay direct, and a custom chat endpoint always
-       bypasses the relay. */
+       Embeddings retain their own route. The published course origins and local file previews
+       default to the bounded NVIDIA DLI relay; other origins stay direct, and a custom chat
+       endpoint always bypasses the relay. */
   if (_cfgPromise) return _cfgPromise;
   _cfgPromise = (async () => {
     const modelApiBaseUrl = getModelApiBaseUrl();


### PR DESCRIPTION
## Summary

Route the default NVIDIA model endpoint through the supported relay on the exact
`https://nvdli.github.io` course origin. Preserve explicit direct mode and custom endpoints,
and expose browser page/resource failures in the Course Assistant runtime result.

## Issue link

Closes #38

## Surfaces touched

- [x] `web/`
- [x] `scripts/`
- [ ] `i18n/`
- [ ] `docs/`
- [ ] `materials/source governance`

## Blast radius checked

Checked default and override routing in `_shared.js`; HTTP, sibling, unrelated, local-file, and
custom-endpoint cases; the learner-flow browser audit; relay-policy mutations; Course Assistant
page/resource diagnostics; authored CodeQL control digests; and EN/ES/PT Pages projections.

## Validation evidence

- [x] PASS — Apple Container doctor
- [x] PASS — Apple Container fast gate: 67/67 checks and 339 tests
- [x] PASS — Apple Container exact-commit Pages build: 90/90 EN/ES/PT
- [x] PASS — exact built artifact: all three Course Assistant artifact prompts validated with no
  chat, page, or resource errors
- [x] PASS — `audit_codeql_sarif.py`

## Human ownership

Vadim Kudlay owns complete-diff review, merge, and release approval. Automated evidence supports
that decision but does not replace it.

## Risk and rollback

The risk is sending a default-endpoint key through the existing relay on an unintended origin.
Exact-origin allowlisting and negative runtime/mutation cases bound that path. Revert
`9485c9c4653f7a4fe1493c70448e15be8c1bbe64` to restore the prior GitHub Pages direct route.

## Out of scope

Hosted-relay implementation or operator policy, custom model endpoints, and OpenClaw
gateway/terminal routing. Localized learner prose is byte-identical.

## Current release target

- Course: static browser course under `web/nemoclaw/`
- Production: public GitHub Pages
- Tooling: Apple Container with repository-managed Python, Node.js, and Chromium
- Bundle scope: course runtime plus bundle-wide routing and security gates

## Security and source impact

No dependency, permission, secret-storage, workflow, licensing, or release-authority change.
The caller's tab-scoped key follows the existing bounded relay path only for the two exact
published origins; direct override and custom endpoints remain direct.

## External release follow-up

- Threat and architecture assessment — NOT APPLICABLE; existing relay trust boundary is unchanged
- Authoritative vulnerability and secret scans — COMPLETE in required GitHub checks
- Open-source and license review — NOT APPLICABLE; no dependency or source change
- Final-artifact SBOM, malware, and release evidence — NOT APPLICABLE; no packaged dependency change

## Release notes

Learner-facing: the GitHub Pages Course Assistant can reach the default NVIDIA model endpoint.

Browser/runtime integration: Pages joins the CDN in the exact-origin relay default; diagnostics
now retain page and resource failures.

Governance/process: relay-policy and model-routing tests cover the new positive and negative cases.
