### PR TITLE
Ban em-dashes in translated course pages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# https://editorconfig.org  — consistent whitespace across editors.
+# https://editorconfig.org keeps whitespace consistent across editors.
 root = true
 
 [*]

--- a/.gitlab/SKILL.html
+++ b/.gitlab/SKILL.html
@@ -67,7 +67,7 @@
   <p>Generic GitLab intake and validation source used when reviewed public commits enter the internal integration repository.</p>
 
   <section aria-labelledby="gitlab-boundary"><h2 id="gitlab-boundary">Why this directory is public</h2>
-    <p>The internal integration repository imports reviewed public commits. This directory keeps the generic validation and intake definitions required for that handoff. Runner addresses, deployment destinations, credentials, account identifiers, and generated artifacts remain outside the public source.</p>
+    <p>This directory keeps the generic validation and intake definitions that the import requires. Runner addresses, deployment destinations, credentials, account identifiers, and generated artifacts remain outside the public source.</p>
   </section>
   <div class="skill-columns">
     <section><h2>Files</h2><ul>

--- a/.gitlab/ci/SKILL.html
+++ b/.gitlab/ci/SKILL.html
@@ -24,10 +24,11 @@
 <ul>
   <li><a href="core.yml"><code>core.yml</code></a> owns the required gate, builds its Pages candidate on the same worker, verifies the copied candidate, renders every HTML page, and then exposes human review.</li>
   <li><a href="sca.yml"><code>sca.yml</code></a> rejects inherited defaults and variables, pins its image, and owns all scanner jobs.</li>
-  <li><a href="privileged.yml"><code>privileged.yml</code></a> runs only trusted default-branch code. Candidate artifacts never receive credentials. CDN preparation has no AWS authority. Publication uses a root-owned program on the protected devbox runner.</li>
+  <li><a href="privileged.yml"><code>privileged.yml</code></a> runs only trusted default-branch code, so candidate artifacts never receive credentials and CDN preparation carries no AWS authority. Publication uses a root-owned program on the protected devbox runner.</li>
 </ul>
-<p>The privileged module is internal GitLab integration. Its source remains reviewable, but GitHub
-receives no workflow edge, protected environment, credential, devbox runner, or AWS authority.</p>
+<p>The privileged module stays inside GitLab integration, so its source remains reviewable while
+GitHub receives no workflow edge, protected environment, credential, devbox runner, or AWS
+authority.</p>
 <pre><code>python3 scripts/validation/gitlab_ci_policy.py --self-test
 python3 scripts/validation/gitlab_ci_policy.py</code></pre>
 </main>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ are defined in [`docs/release_artifacts.md`](docs/release_artifacts.md).
   course entrypoint refresh.
 - Thanks to Juan Jose Durillo Barrionuevo for the expert Spanish course translation and developer-language review.
 - Refined Spanish runtime labels and course parity while retaining Juan Jose Durillo Barrionuevo's reviewed prose baseline.
+- Removed the em-dashes from the Spanish and Portuguese course pages by reorganizing each sentence
+  rather than substituting punctuation, following Juan Jose Durillo Barrionuevo's reviewed Spanish
+  prose baseline for voice and bullet structure.
 - Thanks to Vadim Kudlay for clarifying the CLI comparison and its application defaults.
 - Added an optional, history-free relay source projection with parameterized infrastructure,
   request and WebSocket tests, license inventory, and public-source identifier gates.

--- a/docs/agent_process.md
+++ b/docs/agent_process.md
@@ -151,3 +151,24 @@ instructions. Use the rules below when a change also affects repository-wide ter
 - Never commit a contributor home, mounted drive, cache, tool-runtime, or absolute local file URI.
   Use repository-relative paths, environment variables, or `scripts/runtime/` discovery helpers.
   Then run `python3 -m unittest discover -v -s tests/validation` and the local-path audit itself.
+
+## Context hygiene across compaction
+
+Checkpoint discipline keeps the objective across a compaction. It does not keep the window small.
+Agent harnesses preserve user messages verbatim through compaction, so anything pasted into one is
+replayed into every later window for the rest of the thread. A pasted screenshot is stored as an
+inline base64 `data:` URI, so it never ages out.
+
+This is measurable, not hypothetical. Two long-running sessions against this repository each
+carried about 2.3 MB into every window; roughly 85% of that was three screenshots pasted 17 days
+earlier and unrelated to the work in progress. One had compacted 169 times. Both still delivered,
+but each window reopened near the ceiling and compacted again within half an hour.
+
+- Attach an image once, then refer to it by path. Send a path instead of a paste when several
+  images are coming, and keep long logs and artifact listings in a file the agent can read.
+- Read frequent compaction as a signal to inspect what is being carried, not only as a prompt to
+  re-summarize. When attachments rather than the checkpoint dominate the window, say so.
+- Forking copies the carried context, pinned attachments included. Fork to branch the work; start
+  a fresh thread, seeded with the handoff block, to escape a bloated window.
+- Prefer a durable artifact to a long transcript. Evidence that belongs to the contribution goes in
+  the branch, the issue, or the pull request, where it survives a fresh session at no window cost.

--- a/i18n/es/localization_state.json
+++ b/i18n/es/localization_state.json
@@ -210,14 +210,14 @@
     "web/nemoclaw/02a-routing.html": {
       "source_sha256": "518ec1ff0f4a2e8978e6639f973bf3242dcaa5a88634711f454d072d6cbd2a1f",
       "translation_sha256": "b21fcbcab8bd529a2056abe6e87236fa644997b100d1a3d65e1740088ad01f33",
-      "target_sha256": "66380596b6638a7385e845519e60be32b13956740197343b6d059a46fc3cd469",
-      "reviewed_on": "2026-07-14"
+      "target_sha256": "5ea2d74308809feac8ee0ca19607c7bc10fe5938ec8eb96b4885c49b3328086f",
+      "reviewed_on": "2026-07-25"
     },
     "web/nemoclaw/02b-rag.html": {
       "source_sha256": "242f155c58d9e979bcdef69572f8f64eba89c91419de26feb03635b6b1418808",
       "translation_sha256": "99e766e67bada57a790c27b4091a77a3dec6c8be9685b44eb2539b03c0f205ce",
-      "target_sha256": "24ef1fa1a90d7e842e287a2804dffda0a615b8989f2c0f4129568e9e603215a0",
-      "reviewed_on": "2026-07-14"
+      "target_sha256": "dab0d2a4431a7e12653959b70f8fd0d3ce424ff02567c7b326bb271adef41f85",
+      "reviewed_on": "2026-07-25"
     },
     "web/nemoclaw/02c-deep.html": {
       "source_sha256": "9dbc4e4ff42b79d0cec1a583b108dafcc90cf98816b0fc404db1221d4cea4e81",

--- a/i18n/es/web/nemoclaw/02a-routing.html
+++ b/i18n/es/web/nemoclaw/02a-routing.html
@@ -248,8 +248,8 @@ compensarlo. Para una tarea lineal que se pueda resolver con un solo prompt no c
   <p>
  Escribe una pregunta que requiere una respuesta especializada. El artefacto la clasifica con una llamada al modelo, dirige el ticket al prompt
  de sistema del especialista correspondiente y transmite su respuesta. Ejecuta el mismo patrón de clasificación y
- enrutamiento mostrado antes. Aquí las categorías corresponden a atención al cliente —facturación, soporte técnico,
- cuenta y otros—, en lugar de especialistas con numeración fija. Al cambiar de dominio solo cambia la lista de categorías; el mecanismo permanece igual.
+ enrutamiento mostrado antes. Aquí las categorías cubren facturación, soporte técnico, cuenta y otros ámbitos
+ de atención al cliente, en lugar de especialistas con numeración fija. Al cambiar de dominio solo cambia la lista de categorías; el mecanismo permanece igual.
  </p>
   <div id="router-cell"></div>
   <div id="router-artifact"></div>

--- a/i18n/es/web/nemoclaw/02b-rag.html
+++ b/i18n/es/web/nemoclaw/02b-rag.html
@@ -249,7 +249,7 @@ y <a href="https://developer.nvidia.com/blog/tips-for-building-a-rag-pipeline-wi
  Un agente de indexación top-K básico afronta una tensión entre recall y precisión que ningún modelo de embeddings elimina. Debes elegir entre fragmentos breves y documentos largos:
  </p>
   <ul>
-    <li>Un fragmento breve representa una idea concreta y produce embeddings precisos. Aporta poco contexto.</li>
+    <li>Los fragmentos breves producen embeddings precisos, pero aportan poco contexto: el vector representa una sola idea concreta.</li>
     <li>Los documentos largos conservan el contexto, pero generan embeddings difusos: el vector promedia muchas ideas.</li>
   </ul>
   <p>

--- a/i18n/es/web/nemoclaw/02b-rag.html
+++ b/i18n/es/web/nemoclaw/02b-rag.html
@@ -249,7 +249,7 @@ y <a href="https://developer.nvidia.com/blog/tips-for-building-a-rag-pipeline-wi
  Un agente de indexación top-K básico afronta una tensión entre recall y precisión que ningún modelo de embeddings elimina. Debes elegir entre fragmentos breves y documentos largos:
  </p>
   <ul>
-    <li>Los fragmentos breves producen embeddings precisos —el vector representa una idea concreta—, pero aportan poco contexto.</li>
+    <li>Un fragmento breve representa una idea concreta y produce embeddings precisos. Aporta poco contexto.</li>
     <li>Los documentos largos conservan el contexto, pero generan embeddings difusos: el vector promedia muchas ideas.</li>
   </ul>
   <p>
@@ -300,7 +300,7 @@ y <a href="https://developer.nvidia.com/blog/tips-for-building-a-rag-pipeline-wi
     <li><strong>Documentos jerárquicos.</strong> Un segmentador conserva la jerarquía de títulos y combina extracción atómica de tablas, punteros al elemento padre y un índice doble para búsqueda estructural y semántica. Se indexan fragmentos hijos para mejorar el recall y se recupera el padre correspondiente para que el modelo lea la cláusula dentro de su sección.</li>
     <li><strong>Recuperación de imágenes de página para figuras y gráficos.</strong> Una configuración con dos espacios vectoriales genera embeddings de la página renderizada y de su texto. Así, la consulta también puede recuperar una figura o diapositiva cuando la respuesta esté en el contenido visual.</li>
     <li><strong>Tablas estructuradas y gobernadas.</strong> No se construyen en este curso. El patrón de producción sitúa una capa semántica entre el agente y los datos por fila, y expone solo las métricas seleccionadas que requiere el paquete.</li>
-    <li><strong>Datos relacionales o grafos.</strong> El agente invoca una herramienta de recorrido de grafos —Cypher, GraphQL o una interfaz propia— en lugar de un almacén vectorial. Recibe un subgrafo cuyas aristas explícitas llegan al prompt y conservan las relaciones entre entidades.</li>
+    <li><strong>Datos relacionales o grafos.</strong> En lugar de un almacén vectorial, el agente invoca una herramienta de recorrido de grafos escrita en Cypher, GraphQL o una interfaz propia. Recibe un subgrafo cuyas aristas explícitas llegan al prompt y conservan las relaciones entre entidades.</li>
   </ul>
     
   

--- a/i18n/pt/web/nemoclaw/02b-rag.html
+++ b/i18n/pt/web/nemoclaw/02b-rag.html
@@ -244,7 +244,7 @@
  Um agente de índice top-K simples enfrenta uma troca entre revocação e precisão que nenhum modelo de incorporação elimina. Você deve escolher entre trechos curtos e documentos longos:
  </p>
   <ul>
-    <li>Trechos curtos produzem incorporações precisas — o vetor representa uma ideia focada —, mas carecem de contexto; uma frase raramente basta para responder.</li>
+    <li>Um trecho curto representa uma ideia focada, e o vetor resultante fica preciso. Falta-lhe contexto, e uma frase raramente basta para responder.</li>
     <li>Documentos longos preservam o contexto, mas produzem incorporações difusas; o vetor representa a média de muitas ideias.</li>
   </ul>
   <p>
@@ -290,15 +290,15 @@
     <li><strong>Documentos hierárquicos.</strong> Um segmentador preserva a hierarquia de títulos e combina extração de tabelas atômicas, ponteiros para o pai e um índice duplo para busca estrutural e semântica. Você indexa trechos filhos pequenos para obter boa revocação e recupera o pai correspondente, permitindo que o modelo leia a cláusula junto com sua seção.</li>
     <li><strong>Recuperação de imagens de página para figuras e gráficos.</strong> Uma configuração com dois espaços vetoriais incorpora a página renderizada e seu texto. Assim, a consulta também pode recuperar uma figura ou um slide quando a resposta estiver nesse conteúdo visual.</li>
     <li><strong>Tabelas estruturadas e governadas.</strong> Não são construídas neste curso. O padrão de produção usa uma camada semântica entre o agente e os dados no nível de linha, expondo apenas as métricas selecionadas exigidas pelo pacote.</li>
-    <li><strong>Dados relacionais ou em grafo.</strong> O agente chama uma ferramenta de travessia de grafo — Cypher, GraphQL ou personalizada — em vez de um armazenamento vetorial. O pacote recebido é um subgrafo cujas arestas explícitas seguem para o prompt, preservando as relações entre entidades.</li>
+    <li><strong>Dados relacionais ou em grafo.</strong> Em vez de um armazenamento vetorial, o agente chama uma ferramenta de travessia de grafo escrita em Cypher, GraphQL ou linguagem personalizada. O pacote recebido é um subgrafo cujas arestas explícitas seguem para o prompt, preservando as relações entre entidades.</li>
   </ul>
 
   <!-- ── Frontier: GraphRAG for global questions ───────────────────────────── -->
   <h2>Quando o top-K é a ferramenta errada: GraphRAG e perguntas globais</h2>
   <p>
  Cada recuperador nesta página responde a uma <em>pergunta local</em>, cuja resposta está em poucas passagens que a similaridade top-K
- consegue encontrar — por exemplo, o que um contrato diz sobre rescisão ou qual artigo
- introduziu o <a href="https://arxiv.org/abs/2212.10496" target="_blank" rel="noopener">HyDE</a>. Outra classe de pergunta não possui resposta em uma passagem isolada. Ao perguntar pelos principais temas de mil documentos,
+ consegue encontrar. O que um contrato diz sobre rescisão e qual artigo
+ introduziu o <a href="https://arxiv.org/abs/2212.10496" target="_blank" rel="noopener">HyDE</a> são perguntas desse tipo. Outra classe de pergunta não possui resposta em uma passagem isolada. Ao perguntar pelos principais temas de mil documentos,
  você descobre que a resposta é difusa demais para existir em um único trecho; ela emerge do corpus inteiro.
  </p>
   <p>

--- a/i18n/pt/web/nemoclaw/03b-openclaw.html
+++ b/i18n/pt/web/nemoclaw/03b-openclaw.html
@@ -377,8 +377,8 @@ if (typeof state.turn !== "function") {
   return;
 }
 const b = await state.turn({ content: state.question, session: "quick-3b-soul-auditor" });
-helpers.log("— SOUL padrão —"); helpers.log(state.a);
-helpers.log("— SOUL de auditor —"); helpers.log(b);
+helpers.log("SOUL padrão"); helpers.log(state.a);
+helpers.log("SOUL de auditor"); helpers.log(b);
 `,
     },
   ],

--- a/i18n/pt/web/nemoclaw/04a-safety.html
+++ b/i18n/pt/web/nemoclaw/04a-safety.html
@@ -673,7 +673,7 @@ helpers.log.details("veredito da política", verdict);
 // Binary identity, made visible: the same host can flip on which binary asks.
 const asOpenclaw = helpers.evalSandboxNetwork({ ...action, binary: "/usr/local/bin/openclaw", method: action.method || "GET", path: action.path || "/" }, policy);
 if (asOpenclaw.action !== verdict.action)
-  helpers.log("nota: como /usr/local/bin/openclaw, o resultado seria " + asOpenclaw.action.toUpperCase() + " — a regra de saída depende do binário, e curl não é esse binário.");
+  helpers.log("nota: a regra de saída depende do binário, e curl não é esse binário. Como /usr/local/bin/openclaw, o resultado seria " + asOpenclaw.action.toUpperCase() + ".");
 return verdict;
 `,
     },
@@ -718,10 +718,10 @@ helpers.log("previsto:  " + state.predicted.toUpperCase());
 helpers.log("observado: " + state.observed.toUpperCase());
 
 helpers.log(match
-  ? "concordam — o sandbox aplica exatamente o que a política reforçada prevê."
+  ? "O sandbox aplica exatamente o que a política reforçada prevê. As duas leituras concordam."
   : state.predicted === "deny"
-    ? "divergem — a política reforçada bloquearia a ação, mas o sandbox ativo a permitiu. Confira 'openshell policy get': Active 0 (Pending) indica que a política reforçada ainda não está ativa. Essa diferença é o achado."
-    : "divergem — a política reforçada permitiria a ação, mas o sandbox a bloqueou; há uma configuração mais restritiva que a representada pelo snapshot.");
+    ? "A política reforçada bloquearia a ação, mas o sandbox ativo a permitiu. As duas leituras divergem. Confira 'openshell policy get': Active 0 (Pending) indica que a política reforçada ainda não está ativa. Essa diferença é o achado."
+    : "A política reforçada permitiria a ação, mas o sandbox a bloqueou. As duas leituras divergem, e há uma configuração mais restritiva que a representada pelo snapshot.");
 return { predicted: state.predicted, observed: state.observed, agree: match };
 `,
     },
@@ -761,7 +761,7 @@ let cfg = null; try { cfg = await state.call("config.get"); } catch (_) {}
 helpers.log("config.get → " + (cfg ? "configuração completa disponível para leitura e alteração (modelo, ferramentas, toolSearch)" : "(não exposto nesta versão)"));
 
 helpers.log("");
-helpers.log("Um token alcança persona, agenda, memória, modelos e configuração — nada disso passa pelo sandbox.");
+helpers.log("O sandbox não vê a persona, a agenda, a memória, os modelos nem a configuração que um token alcança.");
 return { soulBytes: (soul?.content || "").length, crons: (crons?.jobs || []).length, models: (models?.models || []).length };
 `,
     },

--- a/scripts/ci/SKILL.html
+++ b/scripts/ci/SKILL.html
@@ -99,7 +99,7 @@
       <li><strong>Exercise or publish:</strong> a separate secret-free job builds the pinned browser runtime without opening candidate content. Candidate browsers run without protected variables. Live probes receive only environment-scoped file secrets. CDN preparation has no AWS authority; the root-installed devbox publisher accepts only its hash plan.</li>
     </ol>
     <p><a href="../../docs/pages_deploy.md">Open the exact <code>glab</code> branch/language commands and runner provisioning steps.</a></p>
-    <p>These operations are internal GitLab capabilities. Public GitHub receives the source and ordinary validation, but no trigger, secret, protected environment, devbox runner, or AWS authority.</p>
+    <p>These operations stay inside GitLab, so public GitHub receives the source and ordinary validation but no trigger, secret, protected environment, devbox runner, or AWS authority.</p>
   </section>
   <div class="skill-columns">
     <section><h2>Files</h2><ul>

--- a/scripts/dev/push
+++ b/scripts/dev/push
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/dev/push — safe push for the devbox.
+# scripts/dev/push provides a safe push for the devbox.
 # Absorbs CI-report commits from the DGX Spark before pushing so you never
 # see a "non-fast-forward" rejection.  Run instead of `git push`.
 set -euo pipefail

--- a/scripts/pyodide/examples/execution-contract.js
+++ b/scripts/pyodide/examples/execution-contract.js
@@ -424,9 +424,9 @@ def notebook_time(expression, repeat=1):
 
 def notebook_magic():
     return [
-        "value? / value?? — inspect a live object", "!command / %%bash — bounded browser-shell commands",
-        "%%time — time a cell", "%who / %whos — inspect the live namespace", "%pwd / %ls / %cd — use the virtual filesystem",
-        "%pip list — list installed browser packages", "%time / %timeit — time an expression", "%magic — show this list",
+        "value? or value?? inspects a live object", "!command and %%bash run bounded browser-shell commands",
+        "%%time times a cell", "%who and %whos inspect the live namespace", "%pwd, %ls, and %cd use the virtual filesystem",
+        "%pip list shows installed browser packages", "%time and %timeit time an expression", "%magic shows this list",
     ]
 
 helper_defaults = {

--- a/scripts/pyodide/runtime_smoke.mjs
+++ b/scripts/pyodide/runtime_smoke.mjs
@@ -148,8 +148,12 @@ if (!shellReply.ok || !shellReply.stdout.includes("SEPIP OLLEH")) {
   throw new Error(`Bounded browser-shell pipeline did not execute: ${JSON.stringify(shellReply)}`);
 }
 const magicReply = await execute("%magic", {});
-if (!magicReply.ok || !magicReply.display.includes("value? / value??")) {
-  throw new Error("Notebook magic help did not render");
+// Assert the magics a learner actually types, not the prose that describes them, so the
+// help text stays free to satisfy the prose gates.
+const magicTokens = ["value?", "%%bash", "%%time", "%who", "%pwd", "%pip list", "%timeit", "%magic"];
+const missingMagics = magicTokens.filter((token) => !magicReply.display.includes(token));
+if (!magicReply.ok || missingMagics.length) {
+  throw new Error(`Notebook magic help did not render: ${JSON.stringify(missingMagics)}`);
 }
 const prettyReply = await execute("{'outer': {'numbers': list(range(12)), 'ready': True}}", {});
 if (prettyReply.display_type !== "application/json" || prettyReply.display_language !== "json"

--- a/scripts/skills/gen_directory_beacons.py
+++ b/scripts/skills/gen_directory_beacons.py
@@ -55,7 +55,7 @@ SUMMARIES = {
 GUIDANCE = {
     ".gitlab": '''
   <section aria-labelledby="gitlab-boundary"><h2 id="gitlab-boundary">Why this directory is public</h2>
-    <p>The internal integration repository imports reviewed public commits. This directory keeps the generic validation and intake definitions required for that handoff. Runner addresses, deployment destinations, credentials, account identifiers, and generated artifacts remain outside the public source.</p>
+    <p>This directory keeps the generic validation and intake definitions that the import requires. Runner addresses, deployment destinations, credentials, account identifiers, and generated artifacts remain outside the public source.</p>
   </section>''',
     "scripts/ci": '''
   <section aria-labelledby="operator-flow"><h2 id="operator-flow">Operator flow</h2>
@@ -65,7 +65,7 @@ GUIDANCE = {
       <li><strong>Exercise or publish:</strong> a separate secret-free job builds the pinned browser runtime without opening candidate content. Candidate browsers run without protected variables. Live probes receive only environment-scoped file secrets. CDN preparation has no AWS authority; the root-installed devbox publisher accepts only its hash plan.</li>
     </ol>
     <p><a href="../../docs/pages_deploy.md">Open the exact <code>glab</code> branch/language commands and runner provisioning steps.</a></p>
-    <p>These operations are internal GitLab capabilities. Public GitHub receives the source and ordinary validation, but no trigger, secret, protected environment, devbox runner, or AWS authority.</p>
+    <p>These operations stay inside GitLab, so public GitHub receives the source and ordinary validation but no trigger, secret, protected environment, devbox runner, or AWS authority.</p>
   </section>''',
     "scripts/cors-proxy/deployable": '''
   <section aria-labelledby="projection-flow"><h2 id="projection-flow">Verify before use</h2>

--- a/scripts/validation/validate_bundle.py
+++ b/scripts/validation/validate_bundle.py
@@ -1169,15 +1169,14 @@ def run(scope: str = "ship", write: bool = True, stamp: str | None = None, lang:
                          for x in reach.get("strays", []) if isinstance(x, dict) and not x.get("expected")],
     }
 
-    # Translation branch: drop the English-prose suites' findings (they do not apply to the target
-    # language) and strip the em-dash signal from grounding (the dash is ordinary punctuation in most
-    # languages). The structural suites are left untouched, so a translation is still fully gated on
-    # links, layout, the SKILL contract, modules, figures, and cells.
+    # Translation branch: drop the English-prose suites' findings, which score English rhythm and
+    # cadence and do not transfer to the target language. The structural suites are left untouched,
+    # so a translation is still fully gated on links, layout, the SKILL contract, modules, figures,
+    # and cells. The em-dash signal is NOT dropped: the dash is banned repository-wide in every
+    # language, and a translator reintroducing one is the case this branch used to hide.
     if not lang_en:
         for sid in na_suites:
             findings_detail[sid] = []
-        findings_detail["grounding"] = [fo for fo in findings_detail.get("grounding", [])
-                                        if "em-dash" not in (fo.get("detail") or "")]
 
     # Roll the per-finding severities up into the advertised gradient.
     # Layout and foyer failures are required-tier too, but live outside findings_detail.

--- a/web/nemoclaw/assets/localization-es.json
+++ b/web/nemoclaw/assets/localization-es.json
@@ -82,8 +82,8 @@
       "file": "02a-routing.html",
       "source_sha256": "b21fcbcab8bd529a2056abe6e87236fa644997b100d1a3d65e1740088ad01f33",
       "reviewed_source_sha256": "b21fcbcab8bd529a2056abe6e87236fa644997b100d1a3d65e1740088ad01f33",
-      "target_sha256": "66380596b6638a7385e845519e60be32b13956740197343b6d059a46fc3cd469",
-      "reviewed_target_sha256": "66380596b6638a7385e845519e60be32b13956740197343b6d059a46fc3cd469",
+      "target_sha256": "5ea2d74308809feac8ee0ca19607c7bc10fe5938ec8eb96b4885c49b3328086f",
+      "reviewed_target_sha256": "5ea2d74308809feac8ee0ca19607c7bc10fe5938ec8eb96b4885c49b3328086f",
       "status": "current",
       "quality": []
     },
@@ -92,8 +92,8 @@
       "file": "02b-rag.html",
       "source_sha256": "99e766e67bada57a790c27b4091a77a3dec6c8be9685b44eb2539b03c0f205ce",
       "reviewed_source_sha256": "99e766e67bada57a790c27b4091a77a3dec6c8be9685b44eb2539b03c0f205ce",
-      "target_sha256": "24ef1fa1a90d7e842e287a2804dffda0a615b8989f2c0f4129568e9e603215a0",
-      "reviewed_target_sha256": "24ef1fa1a90d7e842e287a2804dffda0a615b8989f2c0f4129568e9e603215a0",
+      "target_sha256": "dab0d2a4431a7e12653959b70f8fd0d3ce424ff02567c7b326bb271adef41f85",
+      "reviewed_target_sha256": "dab0d2a4431a7e12653959b70f8fd0d3ce424ff02567c7b326bb271adef41f85",
       "status": "current",
       "quality": []
     },

--- a/web/nemoclaw/assets/localization-pt.json
+++ b/web/nemoclaw/assets/localization-pt.json
@@ -92,7 +92,7 @@
       "file": "02b-rag.html",
       "source_sha256": "99e766e67bada57a790c27b4091a77a3dec6c8be9685b44eb2539b03c0f205ce",
       "reviewed_source_sha256": "99e766e67bada57a790c27b4091a77a3dec6c8be9685b44eb2539b03c0f205ce",
-      "target_sha256": "f39c39415d80058c79760cf4c6a5bf86cff67dd44ef43890d92773c4dd512a19",
+      "target_sha256": "f0b89f3b95fe0ee10fc834874a1534a59f969d4f608a3814fb1a6c4872d233b7",
       "reviewed_target_sha256": "f39c39415d80058c79760cf4c6a5bf86cff67dd44ef43890d92773c4dd512a19",
       "status": "current",
       "quality": []
@@ -122,7 +122,7 @@
       "file": "03b-openclaw.html",
       "source_sha256": "40cded47ddd5ca3a416268aa15df16dabc4e0af06fdf3e8a475cc3c5d801e3f0",
       "reviewed_source_sha256": "40cded47ddd5ca3a416268aa15df16dabc4e0af06fdf3e8a475cc3c5d801e3f0",
-      "target_sha256": "a3238ca372d747e670b06fcb18bc906070420815c7eef5365d9205b5955bbd1f",
+      "target_sha256": "19754b680bcc547c3f4be8cc417cf9c77453994697e64d25c629f13407b43355",
       "reviewed_target_sha256": "a3238ca372d747e670b06fcb18bc906070420815c7eef5365d9205b5955bbd1f",
       "status": "current",
       "quality": []
@@ -142,7 +142,7 @@
       "file": "04a-safety.html",
       "source_sha256": "fd95e699c9a0612b33e22fa095fb0e04c14c40415884c7058a474618edac404e",
       "reviewed_source_sha256": "fd95e699c9a0612b33e22fa095fb0e04c14c40415884c7058a474618edac404e",
-      "target_sha256": "328cc2f2e8a13ffad066663c6b5fb36d14e288eaef2a1bd59388d11ea1ad994b",
+      "target_sha256": "8620fd8201ff563d112b5a05b60d84cf978cca33298c2b426553a7951fe60ad4",
       "reviewed_target_sha256": "328cc2f2e8a13ffad066663c6b5fb36d14e288eaef2a1bd59388d11ea1ad994b",
       "status": "current",
       "quality": []


### PR DESCRIPTION
## Summary

Bans em-dashes in translated course pages, clears the authored ones, and documents why long agent
threads get expensive. Closes #43.

## Issue link

Closes #43.

## Surfaces touched

- [x] `scripts/validation/validate_bundle.py` removed the translation em-dash exemption
- [x] `i18n/es/**` and `i18n/pt/**` five localized pages, twelve sentences reorganized
- [x] `scripts/pyodide/runtime_smoke.mjs` magic-help assertion repaired
- [x] `scripts/pyodide/examples/execution-contract.js` notebook magic help rewritten
- [x] `scripts/skills/gen_directory_beacons.py` generated beacon prose
- [x] `docs/agent_process.md` context hygiene across compaction

## Blast radius checked

- [x] Generated projections regenerated, not hand-edited; `gen_directory_beacons.py --check` current
- [x] `web/nemoclaw/assets/localization-pt.json` regenerated and committed
- [x] es-ES re-review recorded via `localization_audit.py --accept`
- [x] Post-gate tracked-source drift: none outside gitignored `docs/validation/`

## Validation evidence

Apple Container against head `8f32f52`; no repository Python on the macOS host.

- `release gate: PASS tier=ship executed=91 skipped=0`
- `gradient: 0 required · 2 recommended · 435 consider` (was `0 · 7 · 439`)
- `grounding: em-dash 0 over 121 pages`
- `localization: es-ES current=15 needs-review=0 · pt-BR current=15 needs-review=0`
- `contribution safety: OK (commit signoff)`
- Mutation test: deleting `%who` fails the repaired assertion with `["%who"]`

## Human ownership

Maintainer review required. Spanish changes touch Juan Jose Durillo Barrionuevo's reviewed baseline and
warrant a Spanish-speaking reviewer despite the recorded `--accept`. CI is unverified from the authoring
environment; confirm every required check and host-owned CodeQL green on `8f32f52` before merge.

## Risk and rollback

Low. Prose and validator-scope only, no runtime or build effect. Behavioral change: a translated page
carrying an em-dash now fails the bundle where it previously passed. Revert the branch to roll back.

## Out of scope

- Authored em-dashes no detector walks: `docs/security-architecture.json`/`.svg`,
  `scripts/build/build_security_review_package.py`
- Carve-outs kept: `web/_skill_explorer.js:917` renders the glyph; 12 vendored snapshots
- The 2 remaining `recommended` and 435 `consider` items

## Rationale

`validate_bundle.py` stripped the grounding em-dash signal on every non-English branch, reasoning the
dash is ordinary punctuation in most languages. That hid the case the rule exists to catch: a translator
reintroducing the cadence into a page whose English source carries none. `pt/04a-safety.html` held five
while its English original held zero. English-prose suites stay off the translation branch, since they
score English rhythm, but every language now faces the dash ban.

The twelve occurrences were rewritten by reorganizing each sentence so the aside stops existing, not by
swapping the glyph for a comma, colon, or parenthesis. Where a sibling bullet established a house shape,
`[claim], pero [contrast]: [explanation]`, the rewrite matches it.

`runtime_smoke.mjs` asserted exact magic-help phrasing, colliding with the dash ban. It now asserts the
eight magics a learner types, which is strictly stronger than the single substring it replaced.
