### PR TITLE
Fix production connection browser smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ are defined in [`docs/release_artifacts.md`](docs/release_artifacts.md).
   the gateway token through `/api/agent`, verifies both WebSocket paths, then verifies `/healthz`.
 - Thanks to Vadim Kudlay for reviewing the Spanish and Brazilian Portuguese browser-session
   availability guidance.
+- Thanks to Vadim Kudlay for reviewing the corrected provider-specific connection guidance in
+  Spanish and Brazilian Portuguese.
 - Made an ephemeral launchable instance identifier uncommittable: the sensitive-content boundary now
   rejects a provisioned instance ID in either supported host family from the tree, the index, and
   proposed history, the remaining real identifier was replaced with synthetic fixtures, and every

--- a/i18n/es/localization_state.json
+++ b/i18n/es/localization_state.json
@@ -230,8 +230,8 @@
       "reviewed_on": "2026-07-27"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "a22161886c1bc97c3d4e64d9fc57ac1bef116ba5be44c3a3227deaebe2389ce0",
-      "target_sha256": "463fdd7a69c8990003444648940f2255bb72316ba5ac2c5ab3cfe1c9bef7243c",
+      "source_sha256": "451d46642db2ecd6492111088179ca0723bc2262017b236772a94c7975d04f96",
+      "target_sha256": "ffb7b71a81ff729670605b16335baa22ae457037479601b9f83e263d6bcedb7d",
       "reviewed_on": "2026-07-28"
     },
     "web/nemoclaw/03b-openclaw.html": {

--- a/i18n/es/resources/web/nemoclaw/03a-kickstart.html.json
+++ b/i18n/es/resources/web/nemoclaw/03a-kickstart.html.json
@@ -96,10 +96,10 @@
       "source": "\n      <p>Anyone who can read the launchable environment can read that token,\n        and a reader of the token is an operator with everything above. Module 4\n        turns this from a convenience into the central security question.</p>\n    ",
       "value": "<p>Cualquiera que pueda leer el entorno del launchable también puede leer ese token; quien posea el token es un operador con todas las capacidades anteriores. El Módulo 4 convierte esta comodidad en la pregunta central de seguridad.</p>"
     },
-    "text.6491a05ff572": {
+    "text.7b65aa343238": {
       "type": "text",
-      "source": "\n      A verified Pomerium browser session reads bootstrap metadata directly. A manually supplied\n      Pomerium or Cloudflare session uses the approved provider-bound relay. The probe displays\n      which route it used without displaying the session value.\n    ",
-      "value": "\n      Una sesión de navegador de Pomerium verificada lee los metadatos de inicio directamente. Una sesión de Pomerium o Cloudflare proporcionada manualmente usa el relay aprobado vinculado al proveedor. La sonda muestra qué ruta utilizó sin mostrar el valor de la sesión.\n    "
+      "source": "\n      A Pomerium launchable keeps bootstrap and WebSocket traffic direct: HTTP checks run through\n      its terminal loopback. Cloudflare sends HTTP checks through the approved relay; its WebSockets\n      try the launchable first and can recover through the relay. The probe shows the route without\n      displaying the session value.\n    ",
+      "value": "\n      Un launchable de Pomerium mantiene directo el tráfico de arranque y WebSocket: las comprobaciones HTTP se ejecutan mediante el loopback de su terminal. Cloudflare envía las comprobaciones HTTP mediante el relay aprobado; sus WebSockets prueban primero el launchable y pueden recuperarse mediante el relay. La comprobación muestra la ruta sin revelar la sesión.\n    "
     },
     "rich.3ad92e720d94": {
       "type": "rich",

--- a/i18n/pt/localization_state.json
+++ b/i18n/pt/localization_state.json
@@ -213,8 +213,8 @@
       "reviewed_on": "2026-07-27"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "a22161886c1bc97c3d4e64d9fc57ac1bef116ba5be44c3a3227deaebe2389ce0",
-      "target_sha256": "ef6abec87eb1f2946010b38fa49b6f05f9d237a1f56726182a09794ee8824dbf",
+      "source_sha256": "451d46642db2ecd6492111088179ca0723bc2262017b236772a94c7975d04f96",
+      "target_sha256": "34451ad0f77d3513a1d978d4a6b6c2d2f331acb753701b7edc3263d677c4a106",
       "reviewed_on": "2026-07-28"
     },
     "web/nemoclaw/03b-openclaw.html": {

--- a/i18n/pt/resources/web/nemoclaw/03a-kickstart.html.json
+++ b/i18n/pt/resources/web/nemoclaw/03a-kickstart.html.json
@@ -96,10 +96,10 @@
       "source": "\n      <p>Anyone who can read the launchable environment can read that token,\n        and a reader of the token is an operator with everything above. Module 4\n        turns this from a convenience into the central security question.</p>\n    ",
       "value": "<p>Qualquer pessoa que possa ler o ambiente launchable pode ler esse token, e um leitor do token é um operador com tudo acima. Módulo 4 transforma isso de uma conveniência para a questão de segurança central.</p>"
     },
-    "text.6491a05ff572": {
+    "text.7b65aa343238": {
       "type": "text",
-      "source": "\n      A verified Pomerium browser session reads bootstrap metadata directly. A manually supplied\n      Pomerium or Cloudflare session uses the approved provider-bound relay. The probe displays\n      which route it used without displaying the session value.\n    ",
-      "value": "\n      Uma sessão de navegador do Pomerium verificada lê os metadados de inicialização diretamente. Uma sessão do Pomerium ou Cloudflare fornecida manualmente usa o relay aprovado vinculado ao provedor. A sonda mostra a rota usada sem exibir o valor da sessão.\n    "
+      "source": "\n      A Pomerium launchable keeps bootstrap and WebSocket traffic direct: HTTP checks run through\n      its terminal loopback. Cloudflare sends HTTP checks through the approved relay; its WebSockets\n      try the launchable first and can recover through the relay. The probe shows the route without\n      displaying the session value.\n    ",
+      "value": "\n      Um launchable com Pomerium mantém direto o tráfego de inicialização e WebSocket: as verificações HTTP são executadas pelo loopback do terminal. O Cloudflare envia as verificações HTTP pelo relay aprovado; os WebSockets tentam primeiro o launchable e podem usar o relay para recuperação. A verificação mostra a rota sem revelar a sessão.\n    "
     },
     "rich.3ad92e720d94": {
       "type": "rich",

--- a/scripts/validation/endpoint_registration_audit.py
+++ b/scripts/validation/endpoint_registration_audit.py
@@ -108,6 +108,7 @@ def audit(overrides: dict[str, str] | None = None) -> list[str]:
     connection = text(CONNECTION, overrides)
     runtime = text(RUNTIME_HARNESS, overrides)
     explorer = text(EXPLORER, overrides)
+    browser_integration = text(BROWSER_INTEGRATION, overrides)
 
     storage_contract = (
         'const MODEL_API_BASE_URL_KEY = "nemoclaw_model_api_base_url_v1"',
@@ -140,8 +141,20 @@ def audit(overrides: dict[str, str] | None = None) -> list[str]:
         findings.append("SKILL explorer bypasses the canonical course model registry")
     if "nemoclaw_claw" in explorer or "App.prototype.proxy" in explorer:
         findings.append("SKILL explorer redeclares endpoint or OpenClaw state")
-    if "SKILL explorer model registry handoff failed" not in text("scripts/validation/runtime_integration_browser_audit.py", overrides):
+    if "SKILL explorer model registry handoff failed" not in browser_integration:
         findings.append("browser integration audit does not execute the SKILL explorer model handoff")
+    browser_connection_contract = (
+        "#probe-claw .claw-connection-audit",
+        "results.probe.editableFields !== 2",
+        "results.probe.advancedFields !== 0",
+        "['/api/agent', '/cli/gateway', '/ws/terminal', '/healthz']",
+        "connectionPattern",
+    )
+    for token in browser_connection_contract:
+        if token not in browser_integration:
+            findings.append(f"browser connection audit is stale or incomplete: {token}")
+    if "#probe-claw .claw-help-hint" in browser_integration:
+        findings.append("browser connection audit still waits for the retired multi-field help UI")
 
     openclaw_contract = (
         'const isOpenClaw = connectionKind === "openclaw"',
@@ -277,6 +290,8 @@ def self_test() -> list[str]:
         ("embedding conflated with chat", {SHARED: shared.replace('const EMBEDDING_API_BASE_URL_KEY = "nemoclaw_embedding_api_base_url_v1"', 'const EMBEDDING_API_BASE_URL_KEY = "nemoclaw_model_api_base_url_v1"', 1)}, "registry contract"),
         ("explorer bypasses course model registry", {EXPLORER: explorer.replace("return shared.chat({", "return fetch(self.cfg.proxy, {", 1)}, "SKILL explorer bypasses"),
         ("explorer browser handoff removed", {BROWSER_INTEGRATION: browser_integration.replace("SKILL explorer model registry handoff failed", "browser handoff removed", 1)}, "browser integration audit"),
+        ("browser audit restores retired probe selector", {BROWSER_INTEGRATION: browser_integration.replace("#probe-claw .claw-connection-audit", "#probe-claw .claw-help-hint", 1)}, "browser connection audit"),
+        ("browser audit stops enforcing two fields", {BROWSER_INTEGRATION: browser_integration.replace("results.probe.editableFields !== 2", "results.probe.editableFields !== 5", 1)}, "browser connection audit"),
         ("retired model query restored", {SHARED: shared.replace("export function getModelApiBaseUrl()", 'const legacyModel = new URLSearchParams(location.search).get("base_url");\n\nexport function getModelApiBaseUrl()', 1)}, "retired presenter query parameter"),
         ("retired OpenClaw query restored", {CONNECTION: connection.replace("export function getOpenClawProxyConfig()", 'const legacyLaunchable = new URLSearchParams(location.search).get("openclaw_url");\n\nexport function getOpenClawProxyConfig()', 1)}, "retired presenter query parameter"),
         ("learner advertises retired model query", {pages[0]: en + "\n<p>?model=provider/model</p>\n"}, "advertises retired presenter query parameter"),

--- a/scripts/validation/runtime_integration_browser_audit.py
+++ b/scripts/validation/runtime_integration_browser_audit.py
@@ -435,7 +435,8 @@ async function open(browser, pageName, init) {
     await page.close();
   }
 
-  // 3a: model and OpenClaw registrations stay distinct; the OpenClaw probe writes its registry.
+  // 3a: model and OpenClaw registrations stay distinct. The learner-facing connection
+  // audit owns exactly Base URL and Access session; provider, token, and transport stay derived.
   {
     const { page, errors } = await open(browser, '03a-kickstart.html', () => {
       try {
@@ -446,67 +447,47 @@ async function open(browser, pageName, init) {
         localStorage.setItem('nemoclaw_clawrawurl', 'https://nemoclaw-runtime-audit.brevlab.com');
       } catch (_) {}
     });
-    await page.locator('#probe-claw .claw-help-hint').waitFor({ state: 'visible', timeout: timeoutMs });
-    results.probe = await page.evaluate(async () => {
-      const visibleHint = !!document.querySelector('#probe-claw .claw-help-hint');
-      const helpMarks = document.querySelectorAll('#probe-claw .claw-help-mark').length;
+    await page.locator('#probe-claw .claw-connection-audit').waitFor({ state: 'visible', timeout: timeoutMs });
+    results.probe = await page.evaluate(() => {
+      const root = document.querySelector('#probe-claw .claw-connection-audit');
       const modelUrl = document.querySelector('#probe-llm .claw-url');
-      const launchableUrl = document.querySelector('#probe-claw .claw-url');
+      const launchableUrl = root?.querySelector('.claw-url');
+      const accessSession = root?.querySelector('.claw-access-session');
       const registered = {
         model: modelUrl?.value,
         launchable: launchableUrl?.value,
         modelReadOnly: !!modelUrl?.readOnly,
         modelSourceVisible: (document.querySelector('#model-route-settings')?.textContent || '').includes('https://model-runtime-audit.brevlab.com/v1'),
       };
-      localStorage.clear();
-      const host = document.createElement('section');
-      document.body.appendChild(host);
-      const mod = await import('./scripts/_openclaw.js?runtime-audit=' + Date.now());
-      const realFetch = window.fetch;
-      window.fetch = async () => new Response(JSON.stringify({
-        agent: { dashboardUrl: '/#token=AbCd_ef-0123456789.uvwxyz~token' },
-      }), { status: 200, headers: { 'content-type': 'application/json' } });
-      const probe = mod.mountClawProbe(host, {
-        defaultUrl: 'https://nemoclaw-launchable.brevlab.com',
-        defaultToken: '',
-        syncCanvas: true,
-        cfAccess: true,
-        wsRelayControls: true,
-        helpHint: 'Select the ? for help.',
-        fieldHelp: {
-          url: '<p>URL</p>',
-          token: '<p>token</p>',
-          accessProvider: '<p>provider</p>',
-          accessSession: '<p>session</p>',
-          wsRelay: '<p>recovery</p>',
-        },
-        autofillToken: mod.gatewayTokenFromAgentMetadata,
-        actions: [],
-      });
-      const accessSession = host.querySelector('.claw-access-session');
-      const wsRelay = host.querySelector('.claw-ws-relay-enabled');
+      launchableUrl.value = 'https://nemoclaw-launchable.brevlab.com/chat?session=main#ignored';
+      launchableUrl.dispatchEvent(new Event('input', { bubbles: true }));
       accessSession.value = 'synthetic-access-value';
       accessSession.dispatchEvent(new Event('input', { bubbles: true }));
-      wsRelay.click();
-      await probe.run({ path: '/api/agent', method: 'GET' });
-      window.fetch = realFetch;
       return {
-        visibleHint,
-        helpMarks,
+        visible: !!root,
         registered,
+        editableFields: root?.querySelectorAll('input').length || 0,
+        advancedFields: root?.querySelectorAll(
+          '.claw-token,.claw-access-provider,.claw-ws-relay-enabled,.claw-help-mark'
+        ).length || 0,
+        steps: Array.from(root?.querySelectorAll('.claw-audit-step') || [])
+          .map(step => step.querySelector('code')?.textContent || ''),
         url: localStorage.getItem('nemoclaw_clawrawurl'),
         token: sessionStorage.getItem('nemoclaw_clawtoken'),
         access: sessionStorage.getItem('nemoclaw_openclaw_access_session_v1'),
-        wsRelay: probe.getWsRelayEnabled(),
+        persistentAccess: localStorage.getItem('nemoclaw_openclaw_access_session_v1'),
       };
     });
-    if (!results.probe.visibleHint || results.probe.helpMarks !== 5 ||
+    if (!results.probe.visible || results.probe.editableFields !== 2 ||
+        results.probe.advancedFields !== 0 ||
+        JSON.stringify(results.probe.steps) !== JSON.stringify(['/api/agent', '/cli/gateway', '/ws/terminal', '/healthz']) ||
         results.probe.registered.model !== 'https://model-runtime-audit.brevlab.com/v1' ||
         results.probe.registered.launchable !== 'https://nemoclaw-runtime-audit.brevlab.com' ||
         !results.probe.registered.modelReadOnly || !results.probe.registered.modelSourceVisible ||
         results.probe.url !== 'https://nemoclaw-launchable.brevlab.com' ||
-        results.probe.token !== 'AbCd_ef-0123456789.uvwxyz~token' ||
-        results.probe.access !== 'synthetic-access-value' || !results.probe.wsRelay) {
+        results.probe.token !== null ||
+        results.probe.access !== 'synthetic-access-value' ||
+        results.probe.persistentAccess !== null) {
       fail('probe handoff failed: ' + JSON.stringify(results.probe));
     }
     if (errors.length) fail('3a browser errors: ' + JSON.stringify(errors));
@@ -662,16 +643,18 @@ async function open(browser, pageName, init) {
 
   // Built Pages roots contain locale overlays. Prove runtime guidance stayed translated.
   results.locales = {};
-  for (const [locale, helpPattern, cronPattern, policyPattern] of [
-    ['pt', /Precisa de um valor/, /Adicione uma linha curta[\s\S]*aguardando uma execução cron concluída/i, /Não foi possível interpretar/],
-    ['es', /Necesitas un valor/, /Añade una línea breve[\s\S]*esperando una ejecución cron terminada/i, /No se pudo interpretar/],
+  for (const [locale, connectionPattern, cronPattern, policyPattern] of [
+    ['pt', /URL base[\s\S]*Sessão de acesso[\s\S]*Testar conexão/i, /Adicione uma linha curta[\s\S]*aguardando uma execução cron concluída/i, /Não foi possível interpretar/],
+    ['es', /URL base[\s\S]*Sesión de acceso[\s\S]*Probar conexión/i, /Añade una línea breve[\s\S]*esperando una ejecución cron terminada/i, /No se pudo interpretar/],
   ]) {
     const kickstartPath = `/${locale}/nemoclaw/03a-kickstart.html`;
     if (!fs.existsSync(safeJoin(root, kickstartPath))) continue;
     const kickstart = await open(browser, kickstartPath);
-    await kickstart.page.locator('#probe-claw .claw-help-hint').waitFor({ state: 'visible', timeout: timeoutMs });
-    const hint = await kickstart.page.locator('#probe-claw .claw-help-hint').innerText();
-    if (!helpPattern.test(hint)) fail(`${locale} probe help was de-localized: ${hint}`);
+    await kickstart.page.locator('#probe-claw .claw-connection-audit').waitFor({ state: 'visible', timeout: timeoutMs });
+    const connectionText = await kickstart.page.locator('#probe-claw .claw-connection-audit').innerText();
+    if (!connectionPattern.test(connectionText)) {
+      fail(`${locale} connection audit was de-localized: ${connectionText}`);
+    }
     if (kickstart.errors.length) fail(`${locale} 3a browser errors: ${JSON.stringify(kickstart.errors)}`);
     await kickstart.page.close();
 
@@ -695,7 +678,7 @@ async function open(browser, pageName, init) {
     }
     if (safety.errors.length) fail(`${locale} 4a browser errors: ${JSON.stringify(safety.errors)}`);
     await safety.page.close();
-    results.locales[locale] = { hint, cronLocalized: true, policyLocalized: true };
+    results.locales[locale] = { connectionLocalized: true, cronLocalized: true, policyLocalized: true };
   }
 
   await browser.close();

--- a/web/nemoclaw/03a-kickstart.html
+++ b/web/nemoclaw/03a-kickstart.html
@@ -295,9 +295,10 @@
       Change <code>PATH</code> between <code>/api/agent</code> and <code>/healthz</code> to
       inspect either bootstrap response.</p>
     <p>
-      A verified Pomerium browser session reads bootstrap metadata directly. A manually supplied
-      Pomerium or Cloudflare session uses the approved provider-bound relay. The probe displays
-      which route it used without displaying the session value.
+      A Pomerium launchable keeps bootstrap and WebSocket traffic direct: HTTP checks run through
+      its terminal loopback. Cloudflare sends HTTP checks through the approved relay; its WebSockets
+      try the launchable first and can recover through the relay. The probe shows the route without
+      displaying the session value.
     </p>
 
     <div id="claw-raw-cell"></div>

--- a/web/nemoclaw/assets/localization-es.json
+++ b/web/nemoclaw/assets/localization-es.json
@@ -118,10 +118,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "a22161886c1bc97c3d4e64d9fc57ac1bef116ba5be44c3a3227deaebe2389ce0",
-      "reviewed_source_sha256": "a22161886c1bc97c3d4e64d9fc57ac1bef116ba5be44c3a3227deaebe2389ce0",
-      "target_sha256": "463fdd7a69c8990003444648940f2255bb72316ba5ac2c5ab3cfe1c9bef7243c",
-      "reviewed_target_sha256": "463fdd7a69c8990003444648940f2255bb72316ba5ac2c5ab3cfe1c9bef7243c",
+      "source_sha256": "451d46642db2ecd6492111088179ca0723bc2262017b236772a94c7975d04f96",
+      "reviewed_source_sha256": "451d46642db2ecd6492111088179ca0723bc2262017b236772a94c7975d04f96",
+      "target_sha256": "ffb7b71a81ff729670605b16335baa22ae457037479601b9f83e263d6bcedb7d",
+      "reviewed_target_sha256": "ffb7b71a81ff729670605b16335baa22ae457037479601b9f83e263d6bcedb7d",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-pt.json
+++ b/web/nemoclaw/assets/localization-pt.json
@@ -118,10 +118,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "a22161886c1bc97c3d4e64d9fc57ac1bef116ba5be44c3a3227deaebe2389ce0",
-      "reviewed_source_sha256": "a22161886c1bc97c3d4e64d9fc57ac1bef116ba5be44c3a3227deaebe2389ce0",
-      "target_sha256": "ef6abec87eb1f2946010b38fa49b6f05f9d237a1f56726182a09794ee8824dbf",
-      "reviewed_target_sha256": "ef6abec87eb1f2946010b38fa49b6f05f9d237a1f56726182a09794ee8824dbf",
+      "source_sha256": "451d46642db2ecd6492111088179ca0723bc2262017b236772a94c7975d04f96",
+      "reviewed_source_sha256": "451d46642db2ecd6492111088179ca0723bc2262017b236772a94c7975d04f96",
+      "target_sha256": "34451ad0f77d3513a1d978d4a6b6c2d2f331acb753701b7edc3263d677c4a106",
+      "reviewed_target_sha256": "34451ad0f77d3513a1d978d4a6b6c2d2f331acb753701b7edc3263d677c4a106",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []


### PR DESCRIPTION
## Summary

Fix the production-only browser smoke that failed after #69. The audit now exercises Module 3a's current two-field connection UI instead of waiting for the retired help controls. Provider guidance now states the enforced transport: Pomerium is direct with HTTP terminal-loopback; Cloudflare keeps relay recovery.

## Issue link

Closes #70

## Current release target

- Course: `web/nemoclaw/`
- Production: GitHub Pages
- Bundle scope: course plus validation contract

## Surfaces touched

- [x] `web/`
- [x] `i18n/`
- [x] `scripts/`
- [ ] CI and repository automation

## Blast radius checked

The browser audit verifies two editable fields, no retired advanced controls, URL normalization, ordered `/api/agent` → `/cli/gateway` → `/ws/terminal` → `/healthz` steps, tab-only access-session storage, and ES/PT runtime copy. Mutation tests reject the retired selector and field count.

## Validation evidence

- [x] Apple Container fast gate: PASS, 70/70
- [x] Apple Container ship gate and Pages build: PASS, 93/93; source clean
- [x] Exact built-artifact runtime integration smoke: PASS
- [x] Exact built-artifact browser matrix: PASS, 387/387; zero findings

## Security and source impact

No dependency, permission, secret-storage, source, license, or deploy-authority change. The browser session remains tab-scoped and is never written to local storage.

## Human ownership

Vadim Kudlay owns review, merge, and release. Spanish and Portuguese updates were reviewed by Vadim Kudlay.

## Release notes

Learner-facing: provider-specific connection guidance is accurate.

Browser/runtime integration: production smoke follows the current two-field connection contract.

Governance/process: the endpoint-registration detector now rejects stale browser-smoke assumptions.

## Risk and rollback

Risk is limited to connection audit rendering and the production smoke. Revert this PR to restore the prior behavior.

## Out of scope

No relay deployment or provider policy changes.