### PR TITLE
Fail closed when gateway token bootstrap fails

### DIFF
--- a/scripts/runtime/test_page_runtime.js
+++ b/scripts/runtime/test_page_runtime.js
@@ -770,7 +770,12 @@ function findChrome() {
   const nodeErr = Object.values(nodeStatus).some(v => v.error);
   const noFlows = flowCount === 0;
   const hardFail = errors.length > 0 || nodeErr || !settled || noFlows;
-  const gatewayMissing = !!(CLAW_URL && CLAW_TOKEN)
+  // Supplying a launchable makes gateway evidence mandatory even when
+  // /api/agent fails to discover a token. Otherwise an authentication or relay
+  // regression can erase the token and silently disable the live assertion.
+  const gatewayExpected = !!CLAW_URL
+    && flowRuns.some(flow => flow.expectsGateway);
+  const gatewayMissing = gatewayExpected
     && flowRuns.some(flow => flow.expectsGateway && !flow.gatewayOk);
 
   if (hardFail) console.log('RESULT: FAIL (errors / unsettled nodes / no flows)');

--- a/scripts/validation/gateway_token_audit.mjs
+++ b/scripts/validation/gateway_token_audit.mjs
@@ -261,9 +261,10 @@ function audit(overrides = {}) {
   }
   if (!files.runtime.includes('expectsGateway:')
       || !files.runtime.includes('activity.allFrames > 0 && activity.resOk > 0')
-      || !files.runtime.includes('const gatewayMissing =')
+      || !files.runtime.includes('const gatewayExpected = !!CLAW_URL')
+      || !files.runtime.includes('const gatewayMissing = gatewayExpected')
       || files.runtime.includes('const expectedTools = !!(CLAW_URL && CLAW_TOKEN)')) {
-    findings.push('full-canvas harness must use flow-specific gateway evidence instead of a blanket tool requirement');
+    findings.push('full-canvas harness must fail closed on token bootstrap and use flow-specific gateway evidence');
   }
   if (!files.lab.includes('--cron-contract requires --gateway-only')
       || !files.lab.includes('--cron-contract) cron_contract=1')) {
@@ -327,6 +328,7 @@ function selfTest() {
     ['hidden full-canvas flow click', { runtime: base.runtime.replace("document.querySelectorAll('.cf-btn-run')[i]?.click()", "document.querySelectorAll('.cf-btn-run')[0]?.click()") }],
     ['wrong full-canvas running selector', { runtime: base.runtime.replace("flow?.querySelector('.cf-panel.running')", "flow?.querySelector('.cf-panel.cf-running')") }],
     ['blanket full-canvas tool requirement', { runtime: base.runtime.replace('const gatewayMissing =', 'const expectedTools =') }],
+    ['token-bootstrap false green', { runtime: base.runtime.replace('const gatewayExpected = !!CLAW_URL', 'const gatewayExpected = !!(CLAW_URL && CLAW_TOKEN)') }],
     ['runtime noise filter', { runtimeText: base.runtimeText.replace('/proc\\/self\\/oom_score_adj', '/proc/noise') }],
     ['nested runtime filter', { runtimeText: base.runtimeText.replace('filterOpenClawRuntimeValue(value)', 'removedRuntimeValueFilter(value)') }],
     ['final event delivery', { helper: base.helper.replace('deliverFull(openclawMessageText(pl.message)); done(false);', 'done(false);') }],


### PR DESCRIPTION
## Summary

Fail closed in the full-course live harness whenever `CLAW_URL` is configured but a gateway-backed flow produces no successful gateway evidence. This catches relay/authentication failures even when `/api/agent` fails before token discovery. Add a mutation that restores the old token-dependent guard.

## Issue link

Addresses #72

## Surfaces touched

- [ ] `web/`
- [x] `scripts/`
- [ ] `i18n/`
- [ ] CI and repository automation
- [ ] `docs/`
- [ ] materials/source governance

## Blast radius checked

Live full-course verdicts with `CLAW_URL`; token-bootstrap failures; gateway evidence; runs without `CLAW_URL`; source, exact Pages artifact, deployed Pages, and both direct and relayed Pomerium paths. No learner UI, routing, dependency, locale, provider allowlist, or deployment change.

## Validation evidence

PASS: Apple Container doctor; fast gate 70/70; exact signed-head ship gate 93/93; exact Pages build with clean tracked source; gateway mutation audit; skill contract 11/11 and package validation. PASS: same-origin browser controls and projected relay for both Pomerium launchables. FAIL as intended: source and exact artifact now reject both production relay 401 responses. BLOCKED: hosted relay deployment and Cloudflare success verification.

## Human ownership

Vadim Kudlay owns final review and merge. The infrastructure owner controls hosted relay deployment.

## Risk and rollback

Risk is limited to live full-course verdicts when `CLAW_URL` is set. Runs without a launchable keep existing behavior. Revert the commit to restore the former token-dependent assertion.

## Out of scope

Hosted relay infrastructure deployment; a Cloudflare success claim while the supplied JWT is expired; learner prose/UI; provider mappings; allowlists; dependencies; locales.

## Remaining issue work

Issue #72 remains open until the owning infrastructure repository deploys the already-projected provider-native cookie mapping and production cross-origin Pomerium is green. Cloudflare needs a current authorization token for success-path verification.

## Security and source impact

No credentials, private endpoints, dependencies, permissions, learner prose, or deployment settings changed. Repository sensitive-content and source gates passed.