### PR TITLE
Clarify final Module 3a localization credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ are defined in [`docs/release_artifacts.md`](docs/release_artifacts.md).
 
 ## Unreleased
 
-- Thanks to Vadim Kudlay for reviewing the Spanish and Brazilian Portuguese course-readiness
-  corrections included in the aggregate internal integration.
+- Thanks to Vadim Kudlay for reviewing the final Module 3a connection guidance and its Spanish and
+  Brazilian Portuguese course-readiness corrections for the aggregate internal integration.
 - Thanks to Vadim Kudlay for the four-route Module 3a connection-audit interface feedback.
 - Replaced Module 3a's transport controls with a Base URL and Access session check. Pomerium
   metadata uses the launchable's terminal loopback and its WebSockets stay direct; Cloudflare


### PR DESCRIPTION
## Summary

Clarify the existing Unreleased credit so the final Module 3a connection guidance and its Spanish and Brazilian Portuguese course-readiness review are explicitly recorded for the aggregate parity integration.

## Issue link

Addresses #72

## Surfaces touched

- [x] `docs/`

## Blast radius checked

Reviewed the complete one-file diff, the adjacent Module 3a Changelog entries, contribution-language ownership behavior, generated-source cleanliness, and the complete canonical fast and ship gates.

## Validation evidence

- PASS: `git diff --check`.
- PASS: Apple Container `doctor`.
- PASS: Apple Container `fast-gate`, 70/70.
- PASS: exact signed-head Apple Container `build-pages` before publication.

## Human ownership

Vadim Kudlay requested the final copy, parity integration, and merge and owns the resulting course release. Protected checks and repository policy remain authoritative.

## Risk and rollback

Risk is limited to inaccurate attribution wording. Revert this one commit to restore the prior Changelog text; no course runtime, generated artifact structure, credential path, or relay changes.

## Out of scope

Course runtime behavior, localized learner wording, AWS relay code or deployment, and launchable infrastructure.

## Remaining issue work

Issue #72 remains open for the deployed credentialed same-origin and cross-origin acceptance matrix across Pomerium and Cloudflare. This attribution refinement does not claim that production evidence.

## Security and source impact

None. No dependency, permission, workflow, secret handling, source, license, or release-authority behavior changes.
