### PR TITLE
Bump Playwright runtime to 1.62.0

### DIFF
--- a/.gitlab/ci/core.yml
+++ b/.gitlab/ci/core.yml
@@ -91,7 +91,7 @@ test:
   <<: *with_python_node
   # validate_bundle includes DOM-backed figure geometry, so the producing job must
   # have the same pinned browser runtime later used to verify the staged artifact.
-  image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+  image: mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07
   stage: test
   variables:
     MATERIAL_TOOLS_REQUIRED: "1"
@@ -198,7 +198,7 @@ pages:
   stage: deploy
   # Branch previews rebuild the protected production root, whose bundle gate imports
   # localization/material and browser tooling even when live pulls are disabled.
-  image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+  image: mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07
   variables:
     MATERIAL_TOOLS_REQUIRED: "1"
     BROWSER_TOOLS_REQUIRED: "1"
@@ -473,7 +473,7 @@ pages_smoke:
     - when: never
 
 theme_runtime:
-  image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+  image: mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07
   tags: [pages]
   stage: verify
   needs:

--- a/.gitlab/ci/privileged-child.yml
+++ b/.gitlab/ci/privileged-child.yml
@@ -53,7 +53,7 @@ prepare_live_runtime:
   inherit:
     default: false
     variables: false
-  image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+  image: mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07
   tags: [pages]
   stage: acquire
   timeout: 15m
@@ -80,7 +80,7 @@ live_candidate_interfaces:
   inherit:
     default: false
     variables: false
-  image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+  image: mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07
   tags: [pages]
   stage: validate
   timeout: 30m
@@ -118,7 +118,7 @@ live_interface_review:
   inherit:
     default: false
     variables: false
-  image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+  image: mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07
   tags: [pages]
   stage: validate
   timeout: 30m

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -232,7 +232,7 @@ Sources of truth are the exact lock files named in the Scope column. The same pa
 | material-tooling, security-tooling | urllib3 | 2.7.0 | MIT | [PyPI](https://pypi.org/pypi/urllib3/2.7.0/json); [`scripts/materials/requirements.lock`](scripts/materials/requirements.lock); [`scripts/security/requirements-sca.lock`](scripts/security/requirements-sca.lock) |
 | security-tooling | webcolors | 25.10.0 | BSD-3-Clause | [PyPI](https://pypi.org/pypi/webcolors/25.10.0/json); [`scripts/security/requirements-sca.lock`](scripts/security/requirements-sca.lock) |
 | security-tooling | wheel | 0.47.0 | MIT | [PyPI](https://pypi.org/pypi/wheel/0.47.0/json); [`scripts/security/requirements-sca.lock`](scripts/security/requirements-sca.lock) |
-| browser-validation | playwright-core | 1.61.1 | Apache-2.0 | [npm](https://www.npmjs.com/package/playwright-core/v/1.61.1); [`scripts/runtime/pnpm-lock.yaml`](scripts/runtime/pnpm-lock.yaml) |
+| browser-validation | playwright-core | 1.62.0 | Apache-2.0 | [npm](https://www.npmjs.com/package/playwright-core/v/1.62.0); [`scripts/runtime/pnpm-lock.yaml`](scripts/runtime/pnpm-lock.yaml) |
 
 ### Less common license families and their scope
 

--- a/scripts/compliance/third_party_inventory_audit.py
+++ b/scripts/compliance/third_party_inventory_audit.py
@@ -260,9 +260,9 @@ def audit(overrides: dict[str, str] | None = None) -> list[str]:
             findings.append(f"missing Python package row: {name}=={version}")
         elif row[3] in {"", "BSD", "Apache2.0", "NOASSERTION"}:
             findings.append(f"non-specific Python license identifier: {name}=={version}: {row[3]}")
-    playwright = python_index.get(("playwright-core", "1.61.1"))
+    playwright = python_index.get(("playwright-core", "1.62.0"))
     if not playwright or playwright[0] != "browser-validation" or playwright[3] != "Apache-2.0":
-        findings.append("missing pinned host browser-validation package: playwright-core==1.61.1")
+        findings.append("missing pinned host browser-validation package: playwright-core==1.62.0")
 
     material_rows = rows(section(document, "Third-party course-material relationships"))
     material_paths = {row[0] for row in material_rows if row}

--- a/scripts/runtime/package.json
+++ b/scripts/runtime/package.json
@@ -6,6 +6,6 @@
   "license": "Apache-2.0",
   "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e",
   "devDependencies": {
-    "playwright-core": "1.61.1"
+    "playwright-core": "1.62.0"
   }
 }

--- a/scripts/runtime/pnpm-lock.yaml
+++ b/scripts/runtime/pnpm-lock.yaml
@@ -9,16 +9,16 @@ importers:
   .:
     devDependencies:
       playwright-core:
-        specifier: 1.61.1
-        version: 1.61.1
+        specifier: 1.62.0
+        version: 1.62.0
 
 packages:
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
     hasBin: true
 
 snapshots:
 
-  playwright-core@1.61.1: {}
+  playwright-core@1.62.0: {}

--- a/scripts/security/audit_dependency_locks.py
+++ b/scripts/security/audit_dependency_locks.py
@@ -19,10 +19,10 @@ PAIRS = (
 )
 PIN = re.compile(r"^([A-Za-z0-9_.-]+)(?:\[[^\]]+\])?==([^\s;]+)(?:\s*;\s*.+)?$")
 HASH = re.compile(r"--hash=sha256:[0-9a-f]{64}")
-PLAYWRIGHT_VERSION = "1.61.1"
+PLAYWRIGHT_VERSION = "1.62.0"
 PLAYWRIGHT_IMAGE = (
-    "mcr.microsoft.com/playwright:v1.61.1-noble@sha256:"
-    "5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48"
+    "mcr.microsoft.com/playwright:v1.62.0-noble@sha256:"
+    "baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07"
 )
 PNPM_PACKAGE_MANAGER = (
     "pnpm@10.34.5+sha512."
@@ -162,10 +162,10 @@ def self_test() -> list[str]:
             ("scripts/materials/requirements.lock", "requests==2.34.2", "requests==0.0.1"),
             ("scripts/materials/requirements.lock", "requests==2.34.2 \\", "requests==2.34.2"),
             ("scripts/security/requirements-sca.lock", "pip-audit==2.10.1", "# removed pip-audit"),
-            ("scripts/runtime/package.json", '"playwright-core": "1.61.1"', '"playwright-core": "1.55.0"'),
+            ("scripts/runtime/package.json", '"playwright-core": "1.62.0"', '"playwright-core": "1.55.0"'),
             ("scripts/runtime/package.json", PNPM_PACKAGE_MANAGER, "pnpm@latest"),
-            ("scripts/runtime/pnpm-lock.yaml", "specifier: 1.61.1", "specifier: 1.55.0"),
-            (".gitlab/ci/core.yml", PLAYWRIGHT_IMAGE, "mcr.microsoft.com/playwright:v1.61.1-noble"),
+            ("scripts/runtime/pnpm-lock.yaml", "specifier: 1.62.0", "specifier: 1.55.0"),
+            (".gitlab/ci/core.yml", PLAYWRIGHT_IMAGE, "mcr.microsoft.com/playwright:v1.62.0-noble"),
         )
         for rel, old, new in mutations:
             path = fixture / rel

--- a/scripts/validation/contribution_safety_audit.py
+++ b/scripts/validation/contribution_safety_audit.py
@@ -32,8 +32,8 @@ BROWSER_RUNTIME_CONSUMERS = (
     "branch_preview_runtime_audit.py",
 )
 PINNED_PLAYWRIGHT_IMAGE = (
-    "mcr.microsoft.com/playwright:v1.61.1-noble@sha256:"
-    "5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48"
+    "mcr.microsoft.com/playwright:v1.62.0-noble@sha256:"
+    "baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07"
 )
 DECISION_POLICY = {
     "default": "deny",
@@ -2570,7 +2570,7 @@ def self_test() -> list[str]:
             ("gitlab-immutable-report-reuse", ".gitlab/ci/core.yml", 'bash scripts/build/build_pages.sh "$CI_PROJECT_DIR/candidate"', 'bash scripts/build/build_pages.sh "$CI_PROJECT_DIR/rebuilt-candidate"'),
             ("gitlab-protected-root-worktree", ".gitlab/ci/core.yml", 'git worktree add --quiet --detach /tmp/nemoclaw-prod-root "origin/$prod_ref"', 'git archive "origin/$prod_ref" | tar -x -C /tmp/nemoclaw-prod-root'),
             ("gitlab-image-pin", ".gitlab/ci/core.yml", "node:20-bookworm-slim@sha256:25070a03f077f5860e4f2db8d147380678ed40ead415a21eaffd5a6208f61948", "node:20-bookworm-slim"),
-            ("gitlab-report-browser-runtime", ".gitlab/ci/core.yml", "mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48", "mcr.microsoft.com/playwright:v1.61.1-noble"),
+            ("gitlab-report-browser-runtime", ".gitlab/ci/core.yml", "mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07", "mcr.microsoft.com/playwright:v1.62.0-noble"),
             ("gitlab-runtime-sca", ".gitlab/ci/sca.yml", "npm audit --prefix .cache/runtime-npm-audit --package-lock-only --audit-level=moderate", "echo runtime-audit-skipped"),
             ("gitlab-infrastructure-retry", ".gitlab/ci/core.yml", "runner_system_failure", "runner_unsupported"),
             ("gitlab-script-retry", ".gitlab/ci/core.yml", "runner_system_failure", "script_failure"),

--- a/scripts/validation/gitlab_ci_policy.py
+++ b/scripts/validation/gitlab_ci_policy.py
@@ -25,7 +25,7 @@ include:
 SCA_JOBS = ("security_browser_sca", "security_sca", "security_python_sca")
 PRIVILEGED_DIGESTS = {
     ".gitlab/ci/privileged.yml": "1b143eb94e21e2f2f5e68e8496146fc926bc6bbb86ccb237cfbe9e7baca7c9e0",
-    ".gitlab/ci/privileged-child.yml": "74b074a473f5fa3c81f4f96af250f458639064a55c2d08b95628c77b96834624",
+    ".gitlab/ci/privileged-child.yml": "c2b64ce85ba0be1d7d1d382bcc0d1e26ed9d387d0d2477abc6544fe174aedeff",
 }
 OWNER_PATHS = (
     "/.gitlab-ci.yml",

--- a/scripts/validation/reacs_specialization_exceptions.json
+++ b/scripts/validation/reacs_specialization_exceptions.json
@@ -23,11 +23,11 @@
       "rationale": "Freeze the owner-reviewed public parity validator bytes while course route literals migrate to repository-discovered form-factor metadata.",
       "owning_contract": "web/nemoclaw/interface-inventory.json",
       "migration": "Replace frozen course route literals with generic inventory-derived selectors; any byte or registry change requires a new reviewed baseline.",
-      "baseline_commit": "f918c491d5971c8cd7a32dfe7198943c22eb3bd5",
+      "baseline_commit": "c0f6343c5aa5c2b3897c7239b11f6ca17b99a705",
       "files": {
         "scripts/validation/browser_security_boundary_audit.py": "358070ab5dc2cea5e789754ca1f931770ddf3f9409d87b5c597624b2adc8a4d0",
         "scripts/validation/cell_audit.py": "899dd1ca2c83f21b3363f7a8042300e3cb8faf5a8ad9819521f3b7d582e8dbc3",
-        "scripts/validation/contribution_safety_audit.py": "38da98fe5fe4dd6e7c0dc9dd32db050955e636146c89866a643492c8e2b3f2a9",
+        "scripts/validation/contribution_safety_audit.py": "1a60a34d2504c3f5ec9fa7a1ffcd9b606e6cd6247941662683363df80029d5a6",
         "scripts/validation/course_content_contract.py": "b59e5a0b4bfc0723ae51d8b91f2f5f60053b18e0093bf59157223d18aa13d48a",
         "scripts/validation/course_contract.py": "1412d8abf98038df4a5257cc8bb16b21d0098f9e01728f2ddd5ec36aa55067f4",
         "scripts/validation/endpoint_registration_audit.py": "94c73a894198f726fe9619bcb45e81f0f2d34934ab570fcb49efbc7d7347e0d0",
@@ -47,7 +47,7 @@
         "tests/validation/test_locale_catalog.py": "09e14c1404bc50028f72376b750390b41e91e20be6e7d95ac5239537bc2628d7",
         "tests/validation/test_locale_resource_audit.py": "547dc25d063cace336a9281782cdf8938671be340ab5b083737d9725e3206284",
         "tests/validation/test_model_configuration.py": "e371e47d5366f8d8eb2e6bc19890669fc17812f382222d7f472b20619387634d",
-        "tests/validation/test_theme_runtime_contract.py": "eaecf40760f2f34de5031ef4ebfa176bfb0d28ad314169b63052ff907f29e10c"
+        "tests/validation/test_theme_runtime_contract.py": "bf5439a99b290bbaad83badeb6a5025c4a7616ec703985c0f70977f87dff9ebf"
       },
       "registry_ids": []
     },

--- a/tests/validation/test_theme_runtime_contract.py
+++ b/tests/validation/test_theme_runtime_contract.py
@@ -192,8 +192,8 @@ class ThemeRuntimeContractTests(unittest.TestCase):
         core = (ROOT / ".gitlab/ci/core.yml").read_text(encoding="utf-8")
         test_job = core_job("test", "external_integration_audit")
         image = (
-            "mcr.microsoft.com/playwright:v1.61.1-noble@sha256:"
-            "5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48"
+            "mcr.microsoft.com/playwright:v1.62.0-noble@sha256:"
+            "baed2032d533817f3dbe6425de795788430ba345e819a1201337009ba17c9d07"
         )
         self.assertIn(f"image: {image}", test_job)
         self.assertIn('BROWSER_TOOLS_REQUIRED: "1"', test_job)


### PR DESCRIPTION
## Summary

Bump `playwright-core` from 1.61.1 to 1.62.0, update the exact Noble image digest, and synchronize dependency, CI, inventory, and policy assertions.

## Issue link

Addresses #79

## Current release target

- Course: bundle-wide browser validation tooling
- Production: public static host
- Tooling: pinned Node.js, Playwright, and Chromium validation runtime
- Bundle scope: bundle-wide

## Surfaces touched

- [ ] `web/`
- [ ] `i18n/`
- [x] `scripts/`
- [x] CI and repository automation
- [ ] `docs/`
- [x] `materials/source governance`

## Blast radius checked

Checked both GitLab runners, pnpm lock, dependency policy, inventory, specialization baseline, runtime contracts, localized builds, and Pages.

## Validation evidence

- [x] PASS: fast gate, 70/70 suites, Apple Container
- [x] PASS: ship gate, 93/93 suites, exact signed head
- [x] PASS: Playwright 1.62 API with Chromium revision 1228 on ARM Apple Container
- [x] PASS: exact signed-head Pages build; tracked snapshot source clean
- [ ] REQUIRED: GitHub exact-head amd64 CI against the pinned official image

## Security and source impact

Dependency and CI image pins change. Permissions, secrets, relay code, learner content, and licensing do not. All relevant boundary gates passed.

## External release follow-up

- [x] Threat and architecture assessment: NOT APPLICABLE, runtime dependency pin only
- [ ] Authoritative vulnerability and secret scans: REQUIRED in exact-head CI
- [x] Open-source and license review: COMPLETE through source and inventory gates
- [ ] Final-artifact SBOM, malware, and release evidence: REQUIRED in protected release workflow

## Human ownership

Human review and release authorization are required.

## Release notes

Learner-facing: no content change.

Browser/runtime integration: Playwright core and its CI image move to 1.62.0.

Governance/process: dependency assertions and specialization baseline remain exact-SHA bound.

## Risk and rollback

Risk is browser-runner incompatibility. Revert the two signed commits together to restore 1.61.1 and its prior image digest.

## Out of scope

No learner prose, localization, relay, or deployment change. English, Spanish, and Portuguese learner prose remain byte-identical.

## Remaining issue work

PR #79's one-file Dependabot proposal is superseded by this complete policy-synchronized stack and can be closed after this replacement is accepted.
