### PR TITLE
Fix embedding relay routing

### DIFF
--- a/scripts/security/codeql-vendor-dispositions.json
+++ b/scripts/security/codeql-vendor-dispositions.json
@@ -87,7 +87,7 @@
         }
       ],
       "artifact": "web/nemoclaw/scripts/_shared.js",
-      "artifact_sha256": "06c4219dda414faea25733551134adf64c12cc16992c62c546871c0a63e67f4b",
+      "artifact_sha256": "7bc1f24447166c366cb5ae36686329ee488c045f39a789e3d8693be28d4642e7",
       "decision": "explicit-user-tab-credential-boundary",
       "owner": "course-maintainers",
       "expires": "2026-10-24",

--- a/tests/runtime/test_model_routing.mjs
+++ b/tests/runtime/test_model_routing.mjs
@@ -12,12 +12,14 @@ const {
   defaultIframeProxyModeForLocation,
   fetchRetry,
   getConfig,
+  getEmbeddingConfig,
   getModelRequestPolicy,
   normalizeModelRequestRetries,
   normalizeModelRequestTimeoutMs,
   readModelStreamChunk,
   retryDelayMs,
   setIframeProxyMode,
+  setEmbeddingApiBaseUrl,
   setModelApiBaseUrl,
   setModelRequestRetries,
   setModelRequestTimeoutMs,
@@ -126,6 +128,43 @@ test('CDN default, direct override, and custom endpoint bypass resolve consisten
     const custom = await getConfig();
     assert.equal(custom.iframeProxy, false);
     assert.equal(custom.url, 'https://models.example.test/v1');
+  } finally {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) delete globalThis[name];
+      else globalThis[name] = value;
+    }
+  }
+});
+
+test('embedding route shares relay selection but keeps its own endpoint', async () => {
+  const previous = {
+    location:globalThis.location,
+    localStorage:globalThis.localStorage,
+    sessionStorage:globalThis.sessionStorage,
+  };
+  globalThis.location = new URL('https://nvdli.github.io/NemoClawDLI/nemoclaw/02b-rag.html');
+  globalThis.localStorage = memoryStorage();
+  globalThis.sessionStorage = memoryStorage();
+  try {
+    const relayed = await getEmbeddingConfig();
+    assert.deepEqual(relayed, {
+      mode:'direct',
+      url:'https://nvidia-api-cors-proxy.experiments.courses.nvidia.com/v1',
+      model:'nvidia/llama-nemotron-embed-1b-v2',
+      needsKey:true,
+      iframeProxy:true,
+    });
+
+    setIframeProxyMode(false);
+    const direct = await getEmbeddingConfig();
+    assert.equal(direct.url, DEFAULT_MODEL_API_BASE_URL);
+    assert.equal(direct.iframeProxy, false);
+
+    setIframeProxyMode(true);
+    setEmbeddingApiBaseUrl('https://embedding.example.test/v1');
+    const custom = await getEmbeddingConfig();
+    assert.equal(custom.url, 'https://embedding.example.test/v1');
+    assert.equal(custom.iframeProxy, false);
   } finally {
     for (const [name, value] of Object.entries(previous)) {
       if (value === undefined) delete globalThis[name];

--- a/web/nemoclaw/scripts/_shared.js
+++ b/web/nemoclaw/scripts/_shared.js
@@ -242,13 +242,17 @@ export async function getConfig() {
 export async function getEmbeddingConfig() {
   /* @doc <code>helpers.getEmbeddingConfig()</code> ::
        Returns the persistent embedding <code>{ url, model }</code> route. It defaults to NVIDIA's
-       hosted API and does not change when a learner selects another chat endpoint. */
+       hosted API and does not change when a learner selects another chat endpoint. Published
+       course origins use the same bounded relay selection as chat; custom embedding endpoints
+       remain direct. */
+  const embeddingApiBaseUrl = getEmbeddingApiBaseUrl();
+  const useIframeProxy = iframeProxyModeEnabled() && embeddingApiBaseUrl === DEFAULT_MODEL_API_BASE_URL;
   return {
     mode: "direct",
-    url: getEmbeddingApiBaseUrl(),
+    url: useIframeProxy ? IFRAME_PROXY_URL : embeddingApiBaseUrl,
     model: getEmbeddingModelId(),
     needsKey: true,
-    iframeProxy: false,
+    iframeProxy: useIframeProxy,
   };
 }
 


### PR DESCRIPTION
## Summary

Route default NVIDIA embedding requests through the same approved browser relay selection as chat. This repairs published Pages CORS access while keeping explicit direct mode and learner-supplied embedding endpoints direct.

## Issue link

Closes #92

## Current release target

- Course: static browser course under `web/nemoclaw/`
- Production: public GitHub Pages course
- Tooling: Apple Container Linux, Node.js 24.18.0, Playwright 1.62.0, Chromium
- Bundle scope: course-specific runtime plus reviewed source policy

## Surfaces touched

- [x] `web/`
- [ ] `i18n/`
- [x] `scripts/`
- [ ] CI and repository automation
- [ ] `docs/`
- [ ] `materials/source governance`

## Blast radius checked

Chat and embedding route selection, explicit direct mode, custom embedding endpoints, public Pages CORS preflight, credential-boundary policy, localized Pages build. Localized prose unchanged.

## Validation evidence

- [x] `python3 scripts/validation/release_gate.py --tier fast --no-write` — PASS
- [x] `python3 scripts/validation/release_gate.py --tier ship --no-write` via exact Pages build — PASS
- [x] `node --test tests/runtime/test_model_routing.mjs` — PASS (12/12)
- [x] `bash scripts/build/build_pages.sh /tmp/nemoclaw-pages` — PASS; tracked snapshot clean

## Security and source impact

No dependencies, permissions, secrets, external sources, generated assets, or release authority changed. The reviewed `_shared.js` credential-boundary digest was updated after confirming the relay only applies to default NVIDIA endpoints; custom endpoints remain direct.

## External release follow-up

- [x] Threat and architecture assessment — REQUIRED before protected release
- [x] Authoritative vulnerability and secret scans — REQUIRED before protected release
- [x] Privacy and data-use review — REQUIRED before protected release
- [x] Final-artifact SBOM, malware, and release evidence — REQUIRED before protected release

## Human ownership

Course maintainers own diff review, merge, and protected release approval. Current change has no approval for merge or deployment.

## Release notes

Learner-facing: default embedding calls work from published Pages.

Browser/runtime integration: default NVIDIA embedding route follows approved relay; direct and custom routes do not.

Governance/process: source-bound credential review refreshed.

## Risk and rollback

Risk: a route-selection regression. Roll back `fc138033198b1d4bfd62421dd412db7d1526d1a7` to restore former direct behavior.

## Out of scope

Relay-service changes, endpoint availability, credentials, localization prose, and deployment.
