### PR TITLE
Fix CodeQL false positives in contribution diagnostics

### DIFF
--- a/scripts/validation/contribution_safety_audit.py
+++ b/scripts/validation/contribution_safety_audit.py
@@ -721,10 +721,11 @@ def audit_workflow_trust_boundaries(
     return out
 
 
-def audit_trusted_contribution_boundary(workflow: str) -> list[dict[str, str]]:
+def audit_trusted_contribution_boundary(
+    workflow: str, out: list[dict[str, str]],
+) -> None:
     """Keep the sole pull_request_target workflow base-owned and candidate-inert."""
     rel = ".github/workflows/contribution-boundary.yml"
-    out: list[dict[str, str]] = []
     if (
         not workflow_has_trigger(workflow, "pull_request_target")
         or workflow_has_trigger(workflow, "pull_request")
@@ -859,7 +860,6 @@ def audit_trusted_contribution_boundary(workflow: str) -> list[dict[str, str]]:
                 "scope the read-only token to the fetch step so the scan runs without it",
             ))
             break
-    return out
 
 
 def release_status_findings(status: dict) -> list[dict[str, str]]:
@@ -952,9 +952,9 @@ def audit_repo(
         ))
     out.extend(audit_workflow_pins(root, overrides))
     out.extend(audit_workflow_trust_boundaries(root, overrides))
-    out.extend(audit_trusted_contribution_boundary(
-        docs[".github/workflows/contribution-boundary.yml"]
-    ))
+    audit_trusted_contribution_boundary(
+        docs[".github/workflows/contribution-boundary.yml"], out,
+    )
     for rel in RETIRED_GUIDANCE:
         if (root / rel).exists():
             out.append(finding("retired-guidance", rel,

--- a/scripts/validation/reacs_specialization_exceptions.json
+++ b/scripts/validation/reacs_specialization_exceptions.json
@@ -27,7 +27,7 @@
       "files": {
         "scripts/validation/browser_security_boundary_audit.py": "a5d3b546a3ce9280952d3dd8e54fbd9e46139cb97f840e4893d268ff2bf65875",
         "scripts/validation/cell_audit.py": "899dd1ca2c83f21b3363f7a8042300e3cb8faf5a8ad9819521f3b7d582e8dbc3",
-        "scripts/validation/contribution_safety_audit.py": "820842f3e77ee48c5962196f639303f6c1e64eb94e2aa8b12f45fe36f6f287f1",
+        "scripts/validation/contribution_safety_audit.py": "37737ae09aaab62a75f1b1699ce56f1355ab647821596aaa8dc236d846f33d90",
         "scripts/validation/course_content_contract.py": "b59e5a0b4bfc0723ae51d8b91f2f5f60053b18e0093bf59157223d18aa13d48a",
         "scripts/validation/course_contract.py": "a2d2cecfc1f9fddd307f60cc34ebb8ea6fc7e43738046485c6ebd14cc748d8be",
         "scripts/validation/endpoint_registration_audit.py": "94c73a894198f726fe9619bcb45e81f0f2d34934ab570fcb49efbc7d7347e0d0",


### PR DESCRIPTION
## Summary

CodeQL toolchain drift moved Python analysis to CLI 2.26.4 and surfaced public alerts #133, #134, and #135 on fixed contribution-safety findings. The trusted-boundary audit now appends those findings to its caller-owned accumulator instead of returning them. Finding content, JSON reports, stdout, and exit behavior remain unchanged.

## Issue link

Closes #108

## Current release target

- Course: static browser course under `web/nemoclaw/`
- Production: public static host
- Tooling: repository validation under `scripts/`
- Bundle scope: bundle-wide validation tooling

## Surfaces touched

- [ ] `web/`
- [ ] `i18n/`
- [x] `scripts/`
- [ ] CI and repository automation
- [ ] `docs/`
- [ ] `materials/source governance`

## Blast radius checked

Checked the trusted-boundary audit, repository aggregation, fixed diagnostic sinks, specialization fingerprint, SARIF policy, sensitive-content boundary, full validator mutation matrix, and localized Pages assembly. No learner or runtime surface changed.

## Validation evidence

- [x] PASS: before-and-after `contribution_safety_audit.py --report` JSON and stdout are byte-identical.
- [x] PASS: contribution-safety mutation self-test and sensitive-content audit.
- [x] PASS: focused CodeQL SARIF, host-scanning, and embedded-validator suites.
- [x] PASS: `release_gate.py --tier fast --no-write`, all 70 selected suites.
- [x] PASS: exact signed-head ship gate, all 93 suites.
- [x] PASS: exact signed-head English, Spanish, Portuguese, and Chinese Pages assembly with clean tracked source.

## Security and source impact

No dependency, permission, workflow, secret-handling, source, license, or release-authority change. Public alerts #133, #134, and #135 must be absent from the current PR analysis before merge.

## External release follow-up

- Threat and architecture assessment: NOT APPLICABLE
- Authoritative vulnerability and secret scans: REQUIRED, exact-head PR CodeQL and contribution boundary
- Open-source and license review: NOT APPLICABLE
- Final-artifact SBOM, malware, and release evidence: NOT APPLICABLE

## Human ownership

Vadim Kudlay owns the complete diff and release request. Independent protected merge approval remains required for the exact green head.

## Release notes

Learner-facing: none.

Browser/runtime integration: none.

Governance/process: preserve contribution diagnostics while avoiding a CodeQL 2.26.4 false-positive flow.

## Risk and rollback

Risk is limited to contribution-safety finding aggregation. Revert this commit to restore the previous return-and-extend flow; byte-identical report and stdout evidence constrain behavior drift.

## Out of scope

CodeQL query configuration, alert dispositions, workflow tool pinning, learner content, and deployment behavior.
