### PR TITLE
Improve course disclosures and expose Brev offer inline

### DIFF
--- a/scripts/validation/learner_flow_runtime_audit.py
+++ b/scripts/validation/learner_flow_runtime_audit.py
@@ -371,15 +371,33 @@ async function waitText(locator, pattern) {
   const offerCard = overviewPage.locator('[data-hover-note]');
   const offerTitle = offerCard.locator('.sys-name');
   const offerTooltip = offerCard.locator('[role="tooltip"]');
+  const offerDisclosure = overviewPage.locator('[data-hover-note-disclosure]');
+  const offerCopy = offerDisclosure.locator('p');
   const expectedOffer = '*NVIDIA is waiving the fee for the Brev launchable for a limited time to the first 25K users (limited to one redemption per user). Once launched, the user will see a $1.00 credit added to their account, enabling them to complete all 4 modules (~4 hours).';
   await offerTooltip.waitFor({ state:'attached' });
-  if ((await offerTitle.innerText()).trim() !== 'NemoClaw launchable on Brev*' || (await offerTooltip.textContent()).trim() !== expectedOffer) throw new Error('Brev offer marker or approved notice drifted');
+  const offerStyles = await offerDisclosure.locator('summary').evaluate(summary => ({
+    fontFamily:getComputedStyle(summary).fontFamily,
+    bodyFontFamily:getComputedStyle(document.body).fontFamily,
+    copyMaxWidth:getComputedStyle(summary.nextElementSibling).maxWidth,
+  }));
+  if ((await offerTitle.innerText()).trim() !== 'NemoClaw launchable on Brev*' ||
+      (await offerTooltip.textContent()).trim() !== expectedOffer ||
+      (await offerCopy.textContent()).trim() !== expectedOffer ||
+      await offerCard.getAttribute('data-hover-note') !== expectedOffer ||
+      (await offerDisclosure.locator('summary').innerText()).trim() !== 'NemoClaw launchable on Brev*') throw new Error('Brev offer disclosure has duplicate or drifting copy');
+  if (offerStyles.fontFamily !== offerStyles.bodyFontFamily || offerStyles.copyMaxWidth !== 'none') throw new Error(`shared disclosure typography regressed: ${JSON.stringify(offerStyles)}`);
+  if (await offerDisclosure.getAttribute('open') !== null) throw new Error('Brev offer disclosure should start collapsed');
+  await offerDisclosure.locator('summary').click();
+  if (!await offerCopy.isVisible()) throw new Error('Brev offer disclosure does not open inline');
   if (await offerTooltip.isVisible()) throw new Error('Brev offer notice is visible before hover or focus');
   await offerTitle.hover();
   if (!await offerTooltip.isVisible()) throw new Error('Brev offer notice does not open on hover');
   await overviewPage.mouse.move(0, 0);
   await offerCard.focus();
   if (!await offerTooltip.isVisible() || await offerCard.getAttribute('aria-describedby') !== await offerTooltip.getAttribute('id')) throw new Error('Brev offer notice is not keyboard-described');
+  await overviewPage.setViewportSize({ width:390, height:844 });
+  const tooltipBox = await offerTooltip.boundingBox();
+  if (!tooltipBox || tooltipBox.x < 0 || tooltipBox.x + tooltipBox.width > 390) throw new Error(`Brev offer tooltip escapes the narrow viewport: ${JSON.stringify(tooltipBox)}`);
   const assistantEntry = overviewPage.locator('.course-assistant-entry');
   await assistantEntry.waitFor({ state:'visible' });
   if (!/session stays in this browser/i.test(await assistantEntry.innerText()) || !/assistant on every lesson/i.test(await assistantEntry.innerText())) {

--- a/web/nemoclaw/scripts/_learning.js
+++ b/web/nemoclaw/scripts/_learning.js
@@ -124,7 +124,7 @@ function mountContentTransparency() {
   if (!main) return;
   const words = profileWords();
   const disclosure = document.createElement("details");
-  disclosure.className = "publication-disclosure";
+  disclosure.className = "course-disclosure publication-disclosure";
   disclosure.dataset.contentTransparency = "ai-assisted-human-reviewed";
 
   const summary = document.createElement("summary");
@@ -140,6 +140,25 @@ function mountContentTransparency() {
   body.append(imageLink, document.createTextNode(" · "), materialLink, document.createTextNode("."));
   disclosure.append(summary, body);
   main.insertBefore(disclosure, main.querySelector(":scope > footer"));
+}
+
+function mountHoverNoteDisclosures(root = document) {
+  root.querySelectorAll("[data-hover-note]").forEach(host => {
+    const anchor = host.closest(".sys-grid") || host;
+    if (anchor.nextElementSibling?.hasAttribute("data-hover-note-disclosure")) return;
+    const title = host.querySelector(".sys-name")?.textContent.trim();
+    const copy = host.dataset.hoverNote?.trim();
+    if (!title || !copy) return;
+    const disclosure = root.createElement("details");
+    disclosure.className = "course-disclosure hover-note-disclosure";
+    disclosure.dataset.hoverNoteDisclosure = "";
+    const summary = root.createElement("summary");
+    summary.textContent = title.endsWith("*") ? title : `${title}*`;
+    const body = root.createElement("p");
+    body.textContent = copy;
+    disclosure.append(summary, body);
+    anchor.insertAdjacentElement("afterend", disclosure);
+  });
 }
 
 export function readLearningDepth() {
@@ -273,5 +292,6 @@ export function mountLearningView() {
   applyLearningDepth("guided");
   mountHashReveal();
   mountContentTransparency();
+  mountHoverNoteDisclosures();
   void mountLearningProfile();
 }

--- a/web/nemoclaw/styles/_style.css
+++ b/web/nemoclaw/styles/_style.css
@@ -167,15 +167,15 @@ body {
 .learning-block > summary:focus-visible { outline: 1px solid var(--learning-scope-color); outline-offset: 3px; }
 .learning-block-body { padding-top: .15em; }
 .learning-block-body > :first-child { margin-top: .9em; }
-.publication-disclosure {
+.course-disclosure {
   margin: 2.6rem 0 1rem; padding: .7rem .9rem; border: 1px solid var(--bd);
   border-radius: 8px; background: var(--e1); color: var(--td); font-size: .82rem;
 }
-.publication-disclosure > summary {
-  cursor: pointer; color: var(--gs); font: 800 .72rem/1.3 var(--mono);
-  letter-spacing: .02em;
+.course-disclosure > summary {
+  cursor: pointer; color: var(--gs); font: 700 .82rem/1.4 var(--sans);
 }
-.publication-disclosure > p { margin: .65rem 0 .1rem; max-width: 78ch; }
+.course-disclosure > p { margin: .65rem 0 .1rem; }
+.hover-note-disclosure { margin-top: .8rem; }
 .embedding-profile { max-width: 720px; margin: 10px 0; overflow-x: auto; }
 .embedding-profile table { width: 100%; min-width: 520px; border-collapse: collapse; font-size: .76rem; }
 .embedding-profile caption { padding: 0 0 7px; color: var(--td); text-align: left; }


### PR DESCRIPTION
## Summary

Improves learner-facing disclosure readability and exposes the Brev offer through a native inline dropdown while preserving the existing hover and focus explanation.

## Issue link

Closes #115

## Current release target

Public Securing Agents course under `web/nemoclaw/`, with GitHub Pages publication only after maintainer approval and merge.

## Surfaces touched

- [x] `web/`
- [x] `scripts/`
- [ ] `i18n/`
- [ ] CI and repository automation
- [ ] `docs/`
- [ ] `materials/source governance`

## Human ownership

Vadim Kudlay approved the exact visual preview and owns the release decision. Protected maintainers retain approval, squash merge, and production release authority.

## Risk and rollback

The shared learning runtime mounts one native `details` control for each element declaring `data-hover-note`. Reverting the squash commit restores the prior presentation; no data, dependency, model, or locale rollback is required.

## Out of scope

No model routing, translated prose, dependency, workflow, credential, or release-authority change.

## Blast radius checked

One shared runtime discovers hover-note consumers without a course or locale allowlist. The dropdown and existing tooltip read the same authored attribute. Runtime coverage checks exact copy identity, idempotent mounting, collapsed and expanded states, sans-serif typography, uncapped paragraph width, keyboard description, and narrow-viewport bounds. English, Spanish, Brazilian Portuguese, and Simplified Chinese Pages routes inherit the control without duplicated resources.

## Validation evidence

- PASS: 70/70 fast gate.
- PASS: 93/93 ship-tier Pages gate, including 507 discovered tests.
- PASS: exact English, Spanish, Brazilian Portuguese, and Simplified Chinese Pages assembly and publication integrity.
- PASS: Chromium interaction on all four locale routes; each has one native dropdown whose body matches its hover-note source.
- PASS: desktop and 390 px mobile visual review; user-approved preview.
- PASS: CodeQL policy, sensitive-content, source, dependency, license, SBOM, learner-flow, and interface gates.

## Security and source impact

No dependencies, permissions, credentials, external sources, CodeQL-reviewed artifacts, or model endpoints changed. Credentials remain tab-scoped and host-only.

## External release follow-up

- Exact-head GitHub checks: REQUIRED.
- Maintainer approval and squash merge: REQUIRED.
- GitHub Pages deployment verification: REQUIRED after merge.

## Release notes

Course disclosures now use normal course typography without the redundant `78ch` cap. The Brev fee-waiver explanation remains available on hover and keyboard focus and is also readable in a native inline dropdown sourced from the same message.
