### PR TITLE
Reject unusable Deep Research findings and verify locale runtimes

### DIFF
--- a/i18n/es/localization_state.json
+++ b/i18n/es/localization_state.json
@@ -229,10 +229,10 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/02c-deep.html": {
-      "source_sha256": "b35eae71ca3fe1789cfd1d5bf011692c1b7ec0f3792ba376f2383dda0f8d4bec",
-      "translation_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "target_sha256": "0f1445c4d38e374d5b38a203ec4b4c28d896d14309657436a87bf6d2f54ede82",
-      "reviewed_on": "2026-09-02"
+      "source_sha256": "002265a052644de3c42b9aa3caac2f8ffa1a41ce0feb1eb0c80ab217513cce36",
+      "translation_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "target_sha256": "16df9cebb9a061862a0a782508f6ab859d8207baf67cd593be94969c186b345d",
+      "reviewed_on": "2026-09-04"
     },
     "web/nemoclaw/03a-kickstart.html": {
       "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",

--- a/i18n/pt/localization_state.json
+++ b/i18n/pt/localization_state.json
@@ -212,10 +212,10 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/02c-deep.html": {
-      "source_sha256": "b35eae71ca3fe1789cfd1d5bf011692c1b7ec0f3792ba376f2383dda0f8d4bec",
-      "translation_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "target_sha256": "7e2f2dbbd7b3b412a03ff4189c99ab752c371d660dd769263dcadd77fc127f69",
-      "reviewed_on": "2026-09-02"
+      "source_sha256": "002265a052644de3c42b9aa3caac2f8ffa1a41ce0feb1eb0c80ab217513cce36",
+      "translation_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "target_sha256": "9ecb30adce17ed00f6629a7b8d2c3260e29bae196b1d6e72edb58c50e4d62196",
+      "reviewed_on": "2026-09-04"
     },
     "web/nemoclaw/03a-kickstart.html": {
       "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",

--- a/i18n/tw/localization_state.json
+++ b/i18n/tw/localization_state.json
@@ -206,10 +206,10 @@
       "reviewed_on": "2026-09-03"
     },
     "web/nemoclaw/02c-deep.html": {
-      "source_sha256": "b35eae71ca3fe1789cfd1d5bf011692c1b7ec0f3792ba376f2383dda0f8d4bec",
-      "translation_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "target_sha256": "55d8d0c76eb7376262dbb47009a3bb29975b60110c067aeae89abd02c14c4f66",
-      "reviewed_on": "2026-09-03"
+      "source_sha256": "002265a052644de3c42b9aa3caac2f8ffa1a41ce0feb1eb0c80ab217513cce36",
+      "translation_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "target_sha256": "e3e88bffa3f74ead4eb9e5554c8d4b1385391f7045406f928140a668fec1f1a1",
+      "reviewed_on": "2026-09-04"
     },
     "web/nemoclaw/03a-kickstart.html": {
       "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",

--- a/i18n/zh/localization_state.json
+++ b/i18n/zh/localization_state.json
@@ -206,10 +206,10 @@
       "reviewed_on": "2026-09-03"
     },
     "web/nemoclaw/02c-deep.html": {
-      "source_sha256": "b35eae71ca3fe1789cfd1d5bf011692c1b7ec0f3792ba376f2383dda0f8d4bec",
-      "translation_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "target_sha256": "3361317c313597c925589a811a4246b7adf87efcabcc6ece4d8fe01eeca4446e",
-      "reviewed_on": "2026-09-02"
+      "source_sha256": "002265a052644de3c42b9aa3caac2f8ffa1a41ce0feb1eb0c80ab217513cce36",
+      "translation_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "target_sha256": "4824da0e8800001843f42e2aeee442a864cc56067864097337615a6a47dcba90",
+      "reviewed_on": "2026-09-04"
     },
     "web/nemoclaw/03a-kickstart.html": {
       "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",

--- a/scripts/validation/runtime_integration_browser_audit.py
+++ b/scripts/validation/runtime_integration_browser_audit.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import tempfile
@@ -17,6 +18,57 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 from scripts.runtime.host_browser import BrowserRuntimeError, environment, run_node
 
+LOCALE_PAGES = ("index.html", "02c-deep.html", "03a-kickstart.html", "03c-always-on.html", "04a-safety.html")
+
+
+def discover_artifact_locales(site: Path) -> list[dict[str, str]]:
+    """Resolve published locale routes before opening any browser pages."""
+    site = site.resolve()
+    manifest = site / "languages.json"
+    if not manifest.exists() and site == ROOT / "web":
+        return [{"code": "en", "locale": "en", "url": "nemoclaw/"}]
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or data.get("schema") != "nemoclaw-languages/1" or data.get("default") != "en":
+        raise ValueError("languages.json must declare the published language schema and English default")
+    languages = data.get("languages")
+    if not isinstance(languages, list) or not languages:
+        raise ValueError("languages.json has no declared languages")
+    routes = []
+    codes, urls = set(), set()
+    for row in languages:
+        if not isinstance(row, dict):
+            raise ValueError("languages.json contains a malformed language declaration")
+        code, locale, url = (row.get(field) for field in ("code", "locale", "url"))
+        if (not isinstance(code, str) or not re.fullmatch(r"[a-z]{2,3}(?:-[a-z0-9]{2,8})*", code)
+                or not isinstance(locale, str) or not re.fullmatch(r"[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*", locale)
+                or not isinstance(url, str) or not re.fullmatch(r"(?:[a-z0-9][a-z0-9-]*/)*nemoclaw/", url)
+                or code in codes or url in urls):
+            raise ValueError(f"languages.json contains an unsafe or duplicate locale route: {row!r}")
+        codes.add(code)
+        urls.add(url)
+        course = site / url
+        for leaf in LOCALE_PAGES:
+            page = (course / leaf).resolve()
+            if not page.is_relative_to(site) or not page.is_file():
+                raise ValueError(f"declared locale {code} is missing a required route: {url}{leaf}")
+        if code == "en":
+            if locale != "en":
+                raise ValueError("the English route must declare locale en")
+        else:
+            metadata = json.loads((course / "assets/locale.json").read_text(encoding="utf-8"))
+            if (not isinstance(metadata, dict) or metadata.get("schema") != "nemoclaw-locale/1"
+                    or metadata.get("url_code") != code or metadata.get("locale") != locale):
+                raise ValueError(f"declared locale {code} does not match its delivered locale metadata")
+        routes.append({"code": code, "locale": locale, "url": url})
+    if "en" not in codes:
+        raise ValueError("languages.json is missing its English default route")
+    for metadata_path in site.glob("**/nemoclaw/assets/locale.json"):
+        route = metadata_path.parent.parent.relative_to(site).as_posix() + "/"
+        if route not in urls:
+            raise ValueError(f"delivered locale route is missing from languages.json: {route}")
+    return routes
+
+
 RUNTIME_JS = r"""
 const http = require('http');
 const fs = require('fs');
@@ -26,6 +78,8 @@ const { chromium } = require('playwright-core');
 const root = process.env.SITE_ROOT || '/site';
 const port = Number(process.env.SITE_PORT || 4198);
 const timeoutMs = Number(process.env.AUDIT_TIMEOUT_MS || 120000);
+const locales = JSON.parse(process.env.ARTIFACT_LOCALES);
+const english = locales.find(locale => locale.code === 'en');
 const retiredBillingHeader = 'x-billing-' + 'source';
 const mime = { '.html':'text/html; charset=utf-8', '.js':'text/javascript; charset=utf-8', '.css':'text/css; charset=utf-8', '.json':'application/json; charset=utf-8', '.svg':'image/svg+xml', '.png':'image/png', '.woff2':'font/woff2' };
 
@@ -46,16 +100,38 @@ const server = http.createServer((req, res) => {
   });
 });
 const listen = () => new Promise(resolve => server.listen(port, '127.0.0.1', resolve));
-const url = page => `http://127.0.0.1:${port}${page.startsWith('/') ? page : '/nemoclaw/' + page}`;
+const url = page => `http://127.0.0.1:${port}${page.startsWith('/') ? page : '/' + english.url + page}`;
 const fail = message => { throw new Error(message); };
+
+function topLevelInitScript(init) {
+  return `if (window === window.top) { (${init.toString()})(); }`;
+}
+
+function courseExplorerPath() {
+  const candidates = [
+    path.posix.join('/', english.url, '_skill_explorer.js'),
+    path.posix.join('/', english.url, '..', '_skill_explorer.js'),
+  ];
+  const found = candidates.find(candidate => fs.existsSync(safeJoin(root, candidate)));
+  if (!found) fail(`missing course explorer script for ${english.url}`);
+  return found;
+}
 
 async function open(browser, pageName, init) {
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   const errors = [];
   page.on('pageerror', error => errors.push(error.message || String(error)));
-  if (init) await page.addInitScript(init);
-  await page.goto(url(pageName), { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+  if (init) await page.addInitScript({ content: topLevelInitScript(init) });
+  const response = await page.goto(url(pageName), { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+  if (!response?.ok()) fail(`course route failed: ${pageName} (${response?.status()})`);
   return { page, errors };
+}
+
+async function openLocale(browser, language, filename, init) {
+  const opened = await open(browser, '/' + language.url + filename, init);
+  const actual = await opened.page.locator('html').getAttribute('lang');
+  if (actual !== language.locale) fail(`${language.code} ${filename}: html.lang ${actual} != ${language.locale}`);
+  return opened;
 }
 
 (async () => {
@@ -391,21 +467,19 @@ async function open(browser, pageName, init) {
     const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
     const errors = [];
     page.on('pageerror', error => errors.push(error.message || String(error)));
-    await page.addInitScript(() => {
+    await page.addInitScript({ content: topLevelInitScript(() => {
       localStorage.setItem('nemoclaw_model_api_base_url_v1', 'https://skill-model.example.test/v1');
       localStorage.setItem('nemoclaw_model_id_v1', 'model/skill-registry');
       sessionStorage.setItem('nvapi', 'test-model-key');
-    });
+    }) });
     const fixtureUrl = `http://127.0.0.1:${port}/endpoint-registry-fixture.html`;
-    const skillExplorerPath = fs.existsSync(path.join(root, '_skill_explorer.js'))
-      ? '/_skill_explorer.js'
-      : '/web/_skill_explorer.js';
+    const skillExplorerPath = courseExplorerPath();
     await page.route(fixtureUrl, route => route.fulfill({
       status: 200,
       contentType: 'text/html',
       body: `<!doctype html><html><head><meta charset="utf-8"><title>Registry fixture</title></head><body>
         <div id="explorer"></div>
-        <script type="application/json" id="explorer-config">{"title":"Registry fixture","files":[{"path":"nemoclaw/scripts/_shared.js","role":"fixture"}]}</script>
+        <script type="application/json" id="explorer-config">{"title":"Registry fixture","files":[{"path":"${english.url}scripts/_shared.js","role":"fixture"}]}</script>
         <script src="${skillExplorerPath}"></script>
       </body></html>`,
     }));
@@ -467,6 +541,113 @@ async function open(browser, pageName, init) {
     results.agentBundle.deepImportCells = imports;
     if (errors.length) fail('2c browser errors: ' + JSON.stringify(errors));
     await page.close();
+  }
+
+  // 2c: exercise admission and recovery through the real research board and model transport.
+  {
+    const repeated = 'Basedellsellsellsellsellsellsellsellsellsellsell';
+    const evidence = 'RAG grounds a model response in retrieved evidence.';
+    const sibling = 'The course moves from model calls through retrieval and agent coordination.';
+    const scenarios = [
+      { name:'recovery', replies:[repeated, evidence], calls:2, failed:0 },
+      { name:'novel-token-recovery', replies:['証拠'.repeat(8), evidence], calls:2, failed:0 },
+      { name:'second-repetitive-failure', replies:[repeated, repeated], calls:2, failed:1 },
+      { name:'empty-response', replies:[''], calls:1, failed:1 },
+      { name:'empty-retry', replies:[repeated, ''], calls:2, failed:1 },
+      { name:'all-workers-failed', replies:[repeated, repeated], calls:2, failed:2, allFailed:true },
+      { name:'partial-evidence', replies:[evidence + ' Coverage gap: evaluation details are missing.'], calls:1, failed:0, gap:1 },
+      { name:'readable-repeated-labels', replies:['Repeated source labels remain readable: RAG, RAG, RAG, RAG, RAG, RAG.'], calls:1, failed:0 },
+    ];
+    const failures = [];
+    results.deepResearch = {};
+    const cases = locales.flatMap(language => scenarios
+      .filter(scenario => language.code === 'en' || ['recovery', 'second-repetitive-failure', 'all-workers-failed'].includes(scenario.name))
+      .map(scenario => ({ ...scenario, language })));
+    for (const scenario of cases) {
+      const { page, errors } = await openLocale(browser, scenario.language, '02c-deep.html', () => {
+        sessionStorage.setItem('nvapi', 'nvapi-deep-audit');
+      });
+      const workerCalls = [[], []];
+      let requests = 0, synthesisInput = null;
+      try {
+        if (scenario.allFailed) await page.setViewportSize({ width:390, height:844 });
+        await page.route('**/chat/completions', async route => {
+          requests++;
+          const body = JSON.parse(route.request().postData() || '{}');
+          const system = body.messages?.[0]?.content || '';
+          const user = body.messages?.[1]?.content || '';
+          let content;
+          if (system.includes('research planner')) {
+            content = JSON.stringify({ branches: [
+              { source:'materials', target:'Retrieval-Augmented Generation (RAG)', goal:'Define RAG' },
+              { source:'section', target:'overview', goal:'Explain how this course builds RAG' },
+            ] });
+          } else if (system.includes('You are a sub-agent')) {
+            const worker = user.includes('GOAL: Define RAG') ? 0 : 1;
+            workerCalls[worker].push(body);
+            content = worker === 0
+              ? scenario.replies[Math.min(workerCalls[worker].length - 1, scenario.replies.length - 1)]
+              : scenario.allFailed ? repeated : sibling;
+          } else {
+            synthesisInput = user;
+            content = scenario.failed
+              ? 'This course builds coordinated agents [2]. The other branch did not return usable evidence.'
+              : 'RAG uses retrieved evidence [1], and this course builds it into coordinated agents [2].';
+          }
+          const frame = JSON.stringify({ choices:[{ delta:{ content }, finish_reason:null }] });
+          const done = JSON.stringify({ choices:[{ delta:{}, finish_reason:'stop' }], usage:{ prompt_tokens:1, completion_tokens:1 } });
+          await route.fulfill({
+            status:200, contentType:'text/event-stream',
+            body:`data: ${frame}\n\ndata: ${done}\n\ndata: [DONE]\n\n`,
+          });
+        });
+        await page.locator('#deep-artifact .chatui-text').fill('What is RAG, and how does this course build it?');
+        await page.locator('#deep-artifact .chatui-send').click();
+        await page.waitForFunction(() => {
+          const board = document.querySelector('.research-board');
+          return ['complete', 'failed'].includes(board?.dataset.state);
+        }, null, { timeout:timeoutMs });
+        const transcript = await page.locator('#deep-artifact').innerText();
+        const failed = await page.locator('.research-thread.failed').count();
+        const gaps = await page.locator('.research-thread.gap').count();
+        const expectedSiblingCalls = scenario.allFailed ? 2 : 1;
+        const expectedRequests = 1 + scenario.calls + expectedSiblingCalls + (scenario.allFailed ? 0 : 1);
+        if (requests !== expectedRequests || workerCalls[0].length !== scenario.calls ||
+            workerCalls[1].length !== expectedSiblingCalls || failed !== scenario.failed || gaps !== (scenario.gap || 0)) {
+          fail(JSON.stringify({ requests, expectedRequests, workerCalls:workerCalls.map(calls => calls.length), failed, gaps }));
+        }
+        for (const calls of workerCalls) {
+          if (calls.length === 2) {
+            const { temperature, ...retry } = calls[1];
+            const { temperature: initialTemperature, ...initial } = calls[0];
+            if (temperature !== 0 || JSON.stringify(retry) !== JSON.stringify(initial)) fail('retry changed its task or exceeded the temperature contract');
+          }
+        }
+        if (/sellsellsell|証拠証拠証拠|\(no finding\)/i.test(transcript) ||
+            (synthesisInput && /sellsellsell|証拠証拠証拠|branch failed|\(no finding\)/i.test(synthesisInput))) {
+          fail('unusable worker output entered the transcript or synthesis corpus');
+        }
+        if (scenario.allFailed) {
+          if (synthesisInput !== null || await page.locator('.research-board').getAttribute('data-state') !== 'failed') {
+            fail('all-failed run attempted synthesis or failed to report failure');
+          }
+        } else if (!synthesisInput?.includes(sibling) || !synthesisInput.includes('[2]')) {
+          fail('surviving evidence lost its stable worker citation');
+        }
+        if (scenario.failed && !scenario.allFailed &&
+            (synthesisInput.includes('[1]') || !synthesisInput.includes('UNAVAILABLE BRANCHES'))) {
+          fail('failed branch remained citable or its coverage limitation disappeared');
+        }
+        if (!scenario.failed && !synthesisInput.includes(scenario.replies.at(-1))) fail('usable or partial evidence was discarded');
+        if (errors.length) fail('browser errors: ' + JSON.stringify(errors));
+        results.deepResearch[scenario.language.code + ':' + scenario.name] = { requests, workerCalls:workerCalls.map(calls => calls.length), failed, gaps, synthesized:synthesisInput !== null };
+      } catch (error) {
+        failures.push(scenario.language.code + ':' + scenario.name + ': ' + error.message);
+      } finally {
+        await page.close();
+      }
+    }
+    if (failures.length) fail('2c research admission failures: ' + JSON.stringify(failures));
   }
 
   // 3a: model and OpenClaw registrations stay distinct. The learner-facing connection
@@ -675,27 +856,34 @@ async function open(browser, pageName, init) {
     await page.close();
   }
 
-  // Built Pages roots contain locale overlays. Prove runtime guidance stayed translated.
+  // Every published locale must retain its declared language and shared runtime contracts.
   results.locales = {};
-  for (const [locale, connectionPattern, cronPattern, policyPattern] of [
-    ['pt', /URL base[\s\S]*Sessão de acesso[\s\S]*Testar conexão/i, /Adicione uma linha curta[\s\S]*aguardando uma execução cron concluída/i, /Não foi possível interpretar/],
-    ['es', /URL base[\s\S]*Sesión de acceso[\s\S]*Probar conexión/i, /Añade una línea breve[\s\S]*esperando una ejecución cron terminada/i, /No se pudo interpretar/],
-  ]) {
-    const kickstartPath = `/${locale}/nemoclaw/03a-kickstart.html`;
-    if (!fs.existsSync(safeJoin(root, kickstartPath))) continue;
-    const kickstart = await open(browser, kickstartPath);
+  const translatedGuidance = {
+    pt: [/URL base[\s\S]*Sessão de acesso[\s\S]*Testar conexão/i, /Adicione uma linha curta[\s\S]*aguardando uma execução cron concluída/i, /Não foi possível interpretar/],
+    es: [/URL base[\s\S]*Sesión de acceso[\s\S]*Probar conexión/i, /Añade una línea breve[\s\S]*esperando una ejecución cron terminada/i, /No se pudo interpretar/],
+  };
+  for (const language of locales) {
+    const locale = language.code;
+    const [connectionPattern, cronPattern, policyPattern] = translatedGuidance[locale] || [];
+    const kickstart = await openLocale(browser, language, '03a-kickstart.html');
     await kickstart.page.locator('#probe-claw .claw-connection-audit').waitFor({ state: 'visible', timeout: timeoutMs });
+    const connectionReady = await kickstart.page.evaluate(async () => {
+      const connection = await import(new URL('./scripts/_connection.js', location.href));
+      const widget = document.querySelector('#probe-claw .claw-connection-audit');
+      return typeof connection.setOpenClawConnection === 'function' &&
+        !!widget.querySelector('.claw-url') && !!widget.querySelector('.claw-access-session');
+    });
     const connectionText = await kickstart.page.locator('#probe-claw .claw-connection-audit').innerText();
-    if (!connectionPattern.test(connectionText)) {
+    if (!connectionReady || (connectionPattern && !connectionPattern.test(connectionText))) {
       fail(`${locale} connection audit was de-localized: ${connectionText}`);
     }
     if (kickstart.errors.length) fail(`${locale} 3a browser errors: ${JSON.stringify(kickstart.errors)}`);
     await kickstart.page.close();
 
-    const cron = await open(browser, `/${locale}/nemoclaw/03c-always-on.html`);
+    const cron = await openLocale(browser, language, '03c-always-on.html');
     await cron.page.locator('#probe-cron .cf-panel-code').first().waitFor({ state: 'attached', timeout: timeoutMs });
     const cronCode = await cron.page.locator('#probe-cron .cf-panel-code').evaluateAll(items => items.map(item => item.value || '').join('\n'));
-    if (!cronPattern.test(cronCode) || !cronCode.includes('state.call("cron.add"') ||
+    if ((cronPattern && !cronPattern.test(cronCode)) || !cronCode.includes('state.call("cron.add"') ||
         !cronCode.includes('sessionTarget: "isolated"') ||
         !cronCode.includes('state.call("cron.runs"') ||
         !cronCode.includes('const POLL_MS = 5000') || cronCode.includes('const WAIT_S = 70')) {
@@ -704,15 +892,16 @@ async function open(browser, pageName, init) {
     if (cron.errors.length) fail(`${locale} 3c browser errors: ${JSON.stringify(cron.errors)}`);
     await cron.page.close();
 
-    const safety = await open(browser, `/${locale}/nemoclaw/04a-safety.html`);
+    const safety = await openLocale(browser, language, '04a-safety.html');
     await safety.page.locator('#cell-live-policy .rc-code').waitFor({ state: 'attached', timeout: timeoutMs });
     const policyCode = await safety.page.locator('#cell-live-policy .rc-code').inputValue();
-    if (!policyPattern.test(policyCode) || !policyCode.includes('p.parseError')) {
+    if ((policyPattern && !policyPattern.test(policyCode)) || !policyCode.includes('p.parseError')) {
       fail(`${locale} policy failure guidance lost translation or parser detail`);
     }
     if (safety.errors.length) fail(`${locale} 4a browser errors: ${JSON.stringify(safety.errors)}`);
     await safety.page.close();
-    results.locales[locale] = { connectionLocalized: true, cronLocalized: true, policyLocalized: true };
+    results.locales[locale] = { htmlLang: language.locale, route: language.url, connectionReady: true,
+      cronContract: true, policyContract: true, translatedGuidanceChecked: !!connectionPattern };
   }
 
   await browser.close();
@@ -740,13 +929,19 @@ def main() -> int:
     if not site_root.exists():
         print(f"runtime_integration_browser_audit: FAIL\n  - site root missing: {site_root}")
         return 1
+    try:
+        locales = discover_artifact_locales(site_root)
+    except (OSError, ValueError) as error:
+        print(f"runtime_integration_browser_audit: FAIL\n  - {error}")
+        return 1
     with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False, encoding="utf-8") as handle:
         handle.write(RUNTIME_JS)
         script = Path(handle.name)
     try:
         proc = run_node(
             script,
-            env=environment(SITE_ROOT=site_root, AUDIT_TIMEOUT_MS=str(args.timeout_ms)),
+            env=environment(SITE_ROOT=site_root, AUDIT_TIMEOUT_MS=str(args.timeout_ms),
+                            ARTIFACT_LOCALES=json.dumps(locales)),
             timeout=args.timeout_ms / 1000 + 60,
         )
     except BrowserRuntimeError as error:

--- a/tests/validation/test_localization_runtime_audit.py
+++ b/tests/validation/test_localization_runtime_audit.py
@@ -2,11 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 
+from scripts.runtime.host_browser import resolve_node_path
 from scripts.validation.localization_runtime_audit import discover_learner_pages
+from scripts.validation.runtime_integration_browser_audit import (
+    LOCALE_PAGES, RUNTIME_JS, discover_artifact_locales,
+)
 
 
 class LocalizationRuntimeDiscoveryTests(unittest.TestCase):
@@ -44,6 +50,147 @@ class LocalizationRuntimeDiscoveryTests(unittest.TestCase):
                 self.write_lessons(*ids)
                 with self.assertRaises(ValueError):
                     discover_learner_pages(self.site, self.manifest)
+
+
+class RuntimeArtifactLocaleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.site = Path(self.temp.name)
+        self.languages = [{"code": "en", "locale": "en", "url": "nemoclaw/"}]
+        self.add_locale(self.languages[0])
+
+    def add_locale(self, row):
+        course = self.site / row["url"]
+        course.mkdir(parents=True, exist_ok=True)
+        for filename in LOCALE_PAGES:
+            (course / filename).write_text(f'<html lang="{row["locale"]}"></html>')
+        if row["code"] != "en":
+            (course / "assets").mkdir(exist_ok=True)
+            (course / "assets/locale.json").write_text(json.dumps({
+                "schema": "nemoclaw-locale/1", "url_code": row["code"], "locale": row["locale"],
+            }))
+        if row not in self.languages:
+            self.languages.append(row)
+        self.write_manifest()
+
+    def write_manifest(self):
+        (self.site / "languages.json").write_text(json.dumps({
+            "schema": "nemoclaw-languages/1", "default": "en", "languages": self.languages,
+        }))
+
+    def test_novel_and_renamed_locale_routes_are_discovered(self):
+        row = {"code": "ja", "locale": "ja-JP", "url": "ja/nemoclaw/"}
+        self.add_locale(row)
+        self.assertEqual(discover_artifact_locales(self.site), self.languages)
+        (self.site / "ja").rename(self.site / "jp")
+        row.update(code="jp", url="jp/nemoclaw/")
+        self.add_locale(row)
+        self.assertEqual(discover_artifact_locales(self.site), self.languages)
+
+    def test_deleted_and_renamed_declared_pages_fail(self):
+        row = {"code": "ja", "locale": "ja-JP", "url": "ja/nemoclaw/"}
+        self.add_locale(row)
+        page = self.site / row["url"] / "03c-always-on.html"
+        renamed = page.with_name("renamed-cron.html")
+        page.rename(renamed)
+        with self.assertRaisesRegex(ValueError, "missing a required route"):
+            discover_artifact_locales(self.site)
+        renamed.unlink()
+        with self.assertRaisesRegex(ValueError, "missing a required route"):
+            discover_artifact_locales(self.site)
+
+    def test_deleting_a_declaration_does_not_hide_its_delivered_locale(self):
+        self.add_locale({"code": "ja", "locale": "ja-JP", "url": "ja/nemoclaw/"})
+        self.languages.pop()
+        self.write_manifest()
+        with self.assertRaisesRegex(ValueError, "missing from languages.json"):
+            discover_artifact_locales(self.site)
+
+    def test_nested_locale_declaration_removal_is_rejected(self):
+        self.add_locale({"code": "ja", "locale": "ja-JP", "url": "preview/ja/nemoclaw/"})
+        self.assertEqual(discover_artifact_locales(self.site), self.languages)
+        self.languages.pop()
+        self.write_manifest()
+        with self.assertRaisesRegex(ValueError, "missing from languages.json"):
+            discover_artifact_locales(self.site)
+
+    def test_missing_published_manifest_fails_instead_of_falling_back_to_source(self):
+        (self.site / "languages.json").unlink()
+        with self.assertRaises(FileNotFoundError):
+            discover_artifact_locales(self.site)
+
+    def test_malformed_duplicate_and_escaping_declarations_fail(self):
+        for change in ({"locale": "unknown??"}, {"code": "../ja"}, {"url": "../ja/nemoclaw/"},
+                       {"url": "https://example.test/nemoclaw/"}, {"url": "ja/nemoclaw/?query"}):
+            with self.subTest(change=change):
+                self.languages = [{"code": "en", "locale": "en", "url": "nemoclaw/"},
+                                  {"code": "ja", "locale": "ja-JP", "url": "ja/nemoclaw/", **change}]
+                self.write_manifest()
+                with self.assertRaises(ValueError):
+                    discover_artifact_locales(self.site)
+        self.languages = [self.languages[0], dict(self.languages[0])]
+        self.write_manifest()
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            discover_artifact_locales(self.site)
+
+    def test_locale_metadata_mismatch_is_rejected(self):
+        row = {"code": "ja", "locale": "ja-JP", "url": "ja/nemoclaw/"}
+        self.add_locale(row)
+        metadata = self.site / row["url"] / "assets/locale.json"
+        metadata.write_text(json.dumps({"schema": "nemoclaw-locale/1", "url_code": "ja", "locale": "en"}))
+        with self.assertRaisesRegex(ValueError, "delivered locale metadata"):
+            discover_artifact_locales(self.site)
+
+
+class RuntimeBrowserFixtureTests(unittest.TestCase):
+    def test_explorer_follows_course_local_and_nested_source_layouts(self):
+        prefix = RUNTIME_JS.split("(async () => {", 1)[0]
+        with tempfile.TemporaryDirectory() as temporary:
+            site = Path(temporary)
+            for course, explorer in (("novel-course/", "novel-course/_skill_explorer.js"),
+                                     ("preview/source/renamed-course/", "preview/source/_skill_explorer.js")):
+                with self.subTest(course=course):
+                    script = site / explorer
+                    script.parent.mkdir(parents=True, exist_ok=True)
+                    script.write_text("// course-owned explorer")
+                    env = {**os.environ, "NODE_PATH": resolve_node_path(), "SITE_ROOT": str(site), "ARTIFACT_LOCALES": json.dumps([
+                        {"code": "en", "url": course},
+                    ])}
+                    result = subprocess.run(["node", "-e", prefix + "console.log(courseExplorerPath());"],
+                                            capture_output=True, text=True, env=env, check=False)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout.strip(), "/" + explorer)
+                    script.unlink()
+                    result = subprocess.run(["node", "-e", prefix + "courseExplorerPath();"],
+                                            capture_output=True, text=True, env=env, check=False)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("missing course explorer script", result.stderr)
+
+    def test_top_level_fixture_does_not_access_sandbox_storage(self):
+        prefix = RUNTIME_JS.split("(async () => {", 1)[0]
+        checks = r"""
+const assert = require('assert/strict');
+const vm = require('vm');
+const script = topLevelInitScript(() => window.sessionStorage.setItem('fixture', 'ready'));
+const top = {}; top.top = top;
+let stored;
+top.sessionStorage = {setItem:(key,value) => stored = [key,value]};
+vm.runInNewContext(script, {window:top});
+assert.deepEqual(stored, ['fixture','ready']);
+let accesses = 0;
+const frame = {top, get sessionStorage() {accesses++; throw new Error('opaque sandbox storage');}};
+const sandbox = {window:frame};
+vm.runInNewContext(script, sandbox);
+assert.equal(accesses, 0);
+assert.throws(() => vm.runInNewContext(script.replace('window === window.top', 'true'), sandbox), /opaque sandbox storage/);
+assert.equal(accesses, 1);
+"""
+        result = subprocess.run(["node", "-e", prefix + checks], capture_output=True, text=True,
+                                env={**os.environ, "NODE_PATH": resolve_node_path(),
+                                     "ARTIFACT_LOCALES": '[{"code":"en","url":"nemoclaw/"}]'},
+                                check=False)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
 
 if __name__ == "__main__":

--- a/web/nemoclaw/02c-deep.html
+++ b/web/nemoclaw/02c-deep.html
@@ -350,16 +350,25 @@ helpers.mountChatUI("#deep-artifact", {
         worker.text = "";
         setWorker(worker, "running", "Extracting evidence…");
 
-        const r = await helpers.chatStream({ messages: [
+        const extraction = { messages: [
           { role: "system", content: (
             "You are a sub-agent. From the SOURCE, extract only what supports the GOAL, in 2-4 sentences."
             + " If coverage is partial, report the supported point and end with 'Coverage gap:' plus what is missing."
             + " Use 'not covered' only when the source has no relevant information at all."
           ) },
           { role: "user", content: "GOAL: " + b.goal + "\n\nSOURCE:\n" + src }],
-          model: FAST, max_tokens: window.DEEP_AGENT_MAX_TOKENS, signal: sig },
-          (token) => streamWorker(worker, token));
-        finding = (r.content || "").trim() || "(no finding)";
+          model: FAST, max_tokens: window.DEEP_AGENT_MAX_TOKENS, signal: sig };
+        let r = await helpers.chatStream(extraction, (token) => streamWorker(worker, token));
+        finding = (r.content || "").trim();
+        const repetitive = text => /([\p{L}\p{N}]{2,12})\1{5,}/iu.test(text);
+        if (repetitive(finding)) {
+          worker.text = "";
+          worker.stream.textContent = "";
+          r = await helpers.chatStream({ ...extraction, temperature: 0 }, streamWorker.bind(null, worker));
+          finding = (r.content || "").trim();
+          if (repetitive(finding)) throw new Error("model returned repetitive text twice");
+        }
+        if (!finding) throw new Error("model returned no finding");
         worker.text = finding;
         worker.stream.textContent = finding;
         const gap = /^not covered\.?$/i.test(finding) || /\bcoverage gap:/i.test(finding);
@@ -371,29 +380,45 @@ helpers.mountChatUI("#deep-artifact", {
       }
       const dt = (performance.now() - bt0) / 1000;
       worker.status.textContent += " · " + dt.toFixed(1) + "s";
-      return { finding, label, src, goal: b.goal, dt, gap: worker.card.classList.contains("gap") };
+      return { n: i + 1, finding, label, src, goal: b.goal, dt,
+        gap: worker.card.classList.contains("gap"), failed: worker.card.classList.contains("failed") };
     };
 
     const results = await Promise.all(branches.map(runBranch));
     const wall = (performance.now() - t0) / 1000;
     const serial = results.reduce((sum, r) => sum + r.dt, 0);
     const gaps = results.filter(r => r.gap).length;
-    boardStatus.textContent = branches.length + " workers complete · " + wall.toFixed(1) +
+    const failed = results.filter(r => r.failed);
+    const accepted = results.filter(r => !r.failed);
+    const failureStatus = failed.map(r => "[" + r.n + "] " + cards[r.n - 1].status.textContent).join(" · ");
+    if (!accepted.length) {
+      board.dataset.state = "failed";
+      boardStatus.textContent = failureStatus;
+      ctx.view.token(failed.map(r => r.label + ": " + r.finding).join("\n"));
+      return;
+    }
+    boardStatus.textContent = accepted.length + " workers complete · " + wall.toFixed(1) +
       "s wall time vs " + serial.toFixed(1) + "s serial" + (gaps ? " · " + gaps + (gaps === 1 ? " coverage gap" : " coverage gaps") : "") + " · synthesizing…";
 
     // ── 3. SYNTHESIZE: one grounded answer from the findings ────────────
-    const findings = results.map((r, i) => "[" + (i + 1) + "] (" + r.label + ")\n" + r.finding).join("\n\n");
+    const findings = accepted.map(r => "[" + r.n + "] (" + r.label + ")\n" + r.finding).join("\n\n");
+    const unavailable = failed.length
+      ? "\n\nUNAVAILABLE BRANCHES (missing coverage):\n" + failed.map(r => r.label + ": " + r.goal).join("\n")
+      : "";
     // Show the findings corpus that each [n] citation maps back to.
-    ctx.view.tool("findings corpus", { findings: results.map((r, i) => ({ n: i + 1, branch: r.label, finding: r.finding })) });
+    ctx.view.tool("findings corpus", { findings: accepted.map(r => ({ n: r.n, branch: r.label, finding: r.finding })) });
     const s = await helpers.chatStream({ messages: [
       { role: "system", content: (
         "You are a research assistant. Answer the user's question using ONLY the findings below, citing each claim with its [n]."
         + " If a finding names a coverage gap or is empty, do not invent; preserve that limitation in the answer."
+        + " Mention unavailable branches as missing coverage; they are not citable findings."
       ) },
-      { role: "user", content: "QUESTION: " + text + "\n\nFINDINGS:\n" + findings }],
+      { role: "user", content: "QUESTION: " + text + "\n\nFINDINGS:\n" + findings + unavailable }],
       model: ctx.model, max_tokens: window.DEEP_AGENT_MAX_TOKENS, signal: sig },
       (tok) => ctx.view.token(tok));   // no reasoning here: the sub-agents did the thinking; keep the synthesis one clean answer
-    boardStatus.textContent = branches.length + " workers + synthesis complete · " + wall.toFixed(1) + "s parallel fan-out";
+    board.dataset.state = "complete";
+    boardStatus.textContent = accepted.length + " workers + synthesis complete · " + wall.toFixed(1) + "s parallel fan-out";
+    if (failureStatus) boardStatus.textContent += " · " + failureStatus;
     if (s.usage) ctx.view.usage({ input: s.usage.prompt_tokens, output: s.usage.completion_tokens, model: s.model });
   },
 });

--- a/web/nemoclaw/assets/localization-es.json
+++ b/web/nemoclaw/assets/localization-es.json
@@ -107,10 +107,10 @@
     {
       "path": "web/nemoclaw/02c-deep.html",
       "file": "02c-deep.html",
-      "source_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "reviewed_source_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "target_sha256": "0f1445c4d38e374d5b38a203ec4b4c28d896d14309657436a87bf6d2f54ede82",
-      "reviewed_target_sha256": "0f1445c4d38e374d5b38a203ec4b4c28d896d14309657436a87bf6d2f54ede82",
+      "source_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "reviewed_source_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "target_sha256": "16df9cebb9a061862a0a782508f6ab859d8207baf67cd593be94969c186b345d",
+      "reviewed_target_sha256": "16df9cebb9a061862a0a782508f6ab859d8207baf67cd593be94969c186b345d",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-pt.json
+++ b/web/nemoclaw/assets/localization-pt.json
@@ -107,10 +107,10 @@
     {
       "path": "web/nemoclaw/02c-deep.html",
       "file": "02c-deep.html",
-      "source_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "reviewed_source_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "target_sha256": "7e2f2dbbd7b3b412a03ff4189c99ab752c371d660dd769263dcadd77fc127f69",
-      "reviewed_target_sha256": "7e2f2dbbd7b3b412a03ff4189c99ab752c371d660dd769263dcadd77fc127f69",
+      "source_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "reviewed_source_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "target_sha256": "9ecb30adce17ed00f6629a7b8d2c3260e29bae196b1d6e72edb58c50e4d62196",
+      "reviewed_target_sha256": "9ecb30adce17ed00f6629a7b8d2c3260e29bae196b1d6e72edb58c50e4d62196",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-tw.json
+++ b/web/nemoclaw/assets/localization-tw.json
@@ -111,10 +111,10 @@
     {
       "path": "web/nemoclaw/02c-deep.html",
       "file": "02c-deep.html",
-      "source_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "reviewed_source_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "target_sha256": "55d8d0c76eb7376262dbb47009a3bb29975b60110c067aeae89abd02c14c4f66",
-      "reviewed_target_sha256": "55d8d0c76eb7376262dbb47009a3bb29975b60110c067aeae89abd02c14c4f66",
+      "source_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "reviewed_source_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "target_sha256": "e3e88bffa3f74ead4eb9e5554c8d4b1385391f7045406f928140a668fec1f1a1",
+      "reviewed_target_sha256": "e3e88bffa3f74ead4eb9e5554c8d4b1385391f7045406f928140a668fec1f1a1",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-zh.json
+++ b/web/nemoclaw/assets/localization-zh.json
@@ -111,10 +111,10 @@
     {
       "path": "web/nemoclaw/02c-deep.html",
       "file": "02c-deep.html",
-      "source_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "reviewed_source_sha256": "7b7d1c3794983a530adc1b15a387b8655474b214935476c074fb88860b564424",
-      "target_sha256": "3361317c313597c925589a811a4246b7adf87efcabcc6ece4d8fe01eeca4446e",
-      "reviewed_target_sha256": "3361317c313597c925589a811a4246b7adf87efcabcc6ece4d8fe01eeca4446e",
+      "source_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "reviewed_source_sha256": "9963227ac66e4025f3fceeeb7d73669e492c19152998679743fd77047a14fda0",
+      "target_sha256": "4824da0e8800001843f42e2aeee442a864cc56067864097337615a6a47dcba90",
+      "reviewed_target_sha256": "4824da0e8800001843f42e2aeee442a864cc56067864097337615a6a47dcba90",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/vendor/browser-dependencies.json
+++ b/web/nemoclaw/vendor/browser-dependencies.json
@@ -1247,15 +1247,15 @@
         },
         {
           "source": "web/nemoclaw/02c-deep.html",
-          "line": 438
+          "line": 463
         },
         {
           "source": "web/nemoclaw/02c-deep.html",
-          "line": 492
+          "line": 517
         },
         {
           "source": "web/nemoclaw/02c-deep.html",
-          "line": 591
+          "line": 616
         },
         {
           "source": "web/nemoclaw/scripts/_chat.js",


### PR DESCRIPTION
## Summary

Retry a repetitive Deep Research worker response once. Empty or repeatedly repetitive output fails visibly and stays outside the citable findings corpus. Surviving workers retain their citation numbers; unavailable branches are reported separately as coverage limitations. All-failed runs stop before synthesis.

The browser audit discovers declared locales and public/preview routes while preserving sandbox storage restrictions. It exercises the actual UI and transport; only external model responses use fixtures.

## Issue link

Fixes #122.

## Surfaces touched

- [x] `web/`: research runtime and generated source references
- [x] `i18n/`: digest bindings
- [x] `scripts/`: browser audit
- [x] Tests: locale discovery and browser initialization

## Blast radius checked

English and declared locales; sandbox and top-level contexts; public and prefixed previews; novel, renamed, deleted, nested, and malformed routes. Tests cover retry/rejection, empty output, total failure, partial evidence, and stable citations. Locale resource bytes, translatable units, editorial text, and existing review dates are unchanged.

## Validation evidence

PASS on signed head `73f62989a72b4cb3c2a2554697a2a25cfbec78e3`: all 94 ship checks, five signed-history audits, public and prefixed preview builds, and full browser audits of both artifacts (20 research scenarios each across five locales). Source remained clean. PASS on the identical source tree: 12 focused tests and 50 affected fast-gate checks (20 unaffected).

## Human ownership

Vadim Kudlay owns this contribution and merge/release decisions. The affected lesson and runtime diff were reviewed. Automated checks do not constitute human approval or locale review.

## Risk and rollback

Finding admission could discard usable evidence or lose citation identity; regressions cover both. Revert this contribution to restore the parent runtime and audit behavior.

## Out of scope

Other PRs, general response scoring, model or endpoint replacement, translated prose, validator baselines, and permission changes.

## Security and source impact

Sandbox and page-error checks remain enforced. No dependency version, SBOM component, bundled asset, credential, or release-authority changes. Generated browser metadata changes only source references.

## External release follow-up

REQUIRED: normal hosted PR checks and exact-main artifact comparison, provenance, deployment, and live verification. Existing publication controls remain in force.
