### PR TITLE
Show model decisions and recover benchmark discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ are defined in [`docs/release_artifacts.md`](docs/release_artifacts.md).
 
 ## Unreleased
 
+- Show the questions, replies, and model identities in the ReAct preview, and make optional
+  model discovery recover from missing matches or a changed connection. Codex reviewed the
+  affected Spanish, Brazilian Portuguese, Simplified Chinese, and Traditional Chinese text
+  at the maintainer's request.
+
 - Thanks to Vadim Kudlay for reviewing the Taiwan Traditional Chinese localization.
 - Thanks to Vadim Kudlay for reviewing the Spanish, Brazilian Portuguese, and Simplified Chinese
   learner guidance for the supported NVIDIA model-role migration and course-wide runtime localization.

--- a/i18n/es/localization_state.json
+++ b/i18n/es/localization_state.json
@@ -236,8 +236,8 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "target_sha256": "8bac4ae27fafcefd6f1d1227321dbfe636fc9fa45043066a677e5165b777cef0",
+      "source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "target_sha256": "20507fd0ca896a0806713c2527924b47152574e67d04d09f24626d5a72b5ed18",
       "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/03b-openclaw.html": {

--- a/i18n/es/localization_state.json
+++ b/i18n/es/localization_state.json
@@ -48,7 +48,8 @@
     "text.b2eef2ab0d7f": "Reviewed Spanish spells out ' mensajes' on 01a-loop and retains the compact trace abbreviation ' msgs' on 02c-deep.",
     "text.dee9df394086": "Reviewed Spanish renders the health-check hint with different closing clauses on 03a-kickstart and 03c-always-on, and drops the source's emoji markers on 03c-always-on only.",
     "text.efefc15c24ee": "Reviewed Spanish retains '(no output)' in two 04a-safety trace paths and uses '(sin salida)' in two 04b-modern-clis terminal paths.",
-    "text.f612a61bab20": "Reviewed Spanish retains the English agent-name hint on 03b-openclaw and localizes the same source on 03c-always-on."
+    "text.f612a61bab20": "Reviewed Spanish retains the English agent-name hint on 03b-openclaw and localizes the same source on 03c-always-on.",
+    "text.1f5087db919c": "Codex reviewed this distinction at the maintainer's request: 01b-react translates the learner-visible log label 'question' as 'pregunta'; 01c-tools and 02b-rag retain 'question' as an executable tool-schema field name."
   },
   "asset_reviews": {
     "web/nemoclaw/assets/figures/01a-agent-environment.svg": {
@@ -205,10 +206,10 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/01b-react.html": {
-      "source_sha256": "99e02192657730a88ed08262938b92c7da8175bcec37cc45e6471f2937b595f0",
-      "translation_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "target_sha256": "ab6440779484d354cd50fc50af70271551477b63b300f6741cb7624e4db8bb84",
-      "reviewed_on": "2026-09-02"
+      "source_sha256": "8cffc7082907c8e65db71a82677f6a1d190fcd59a7f00e32e505e4d0060689d0",
+      "translation_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "target_sha256": "7a39d4f661667a48d5a4e76d1e2a8864a25988a448216808783749ed72d73952",
+      "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/01c-tools.html": {
       "source_sha256": "2df9970a5768081b414813d8a79bd937f82820c318d28f8e26894977d3ddf503",
@@ -235,9 +236,9 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "target_sha256": "c68dadc8bfdf20e51838ffa5adf3379e7a3fc07c2817e2f45d7c6af421ceec32",
-      "reviewed_on": "2026-08-14"
+      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "target_sha256": "8bac4ae27fafcefd6f1d1227321dbfe636fc9fa45043066a677e5165b777cef0",
+      "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/03b-openclaw.html": {
       "source_sha256": "0cda0d39d34e71f9831f39741062f771568f021e2784058c7929bcb619dbf0e3",

--- a/i18n/es/resources/web/nemoclaw/01b-react.html.json
+++ b/i18n/es/resources/web/nemoclaw/01b-react.html.json
@@ -91,11 +91,6 @@
       "value": "(tool \"\\${name}\" not found)",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "rich.0a886834e9f1": {
-      "type": "rich",
-      "source": "\n    Every chat-completions response carries a <code>finish_reason</code>\n    field that tells you why the model stopped generating. Inside an agent\n    loop, this is the only signal you need to decide what to do next:\n    run a tool, return the answer to the user, or handle an error. Before reading\n    what its values mean, make two calls and watch the field change.\n  ",
-      "value": "Cada respuesta de Chat Completions incluye un campo <code>finish_reason</code> que indica por qué\nel modelo dejó de generar tokens. Dentro del bucle del agente, esta señal basta para decidir el paso\nsiguiente: ejecutar una herramienta, devolver la respuesta al usuario o gestionar un error. Antes de revisar\nel significado de cada valor, ejecuta dos llamadas y observa cómo cambia dicho campo."
-    },
     "rich.1cbfc5ef05f8": {
       "type": "rich",
       "source": "<code>\"stop\"</code> means the model has written its final answer and the loop can return <code>content</code> to the user.",
@@ -105,11 +100,6 @@
       "type": "rich",
       "source": "<strong>Memory</strong> is the <code>messages[]</code> array.",
       "value": "La <strong>memoria</strong> es un array <code>messages[]</code>."
-    },
-    "rich.32ec8d5bb853": {
-      "type": "rich",
-      "source": "\n    The first call answered on its own and came back <code>\"stop\"</code>. The second was\n    offered a tool and asked for something training data cannot supply, so instead of stopping\n    it came back <code>\"tool_calls\"</code>, handing your code the name of the function to run.\n    Those two values cover the common branching. The rest signal trouble that routes the loop\n    into a fallback harness, where the agent might retry the call or hand the conversation off\n    to a human.\n  ",
-      "value": "La primera llamada pudo generar una respuesta directamente y devolvió <code>\"stop\"</code>. En la segunda, el\nmodelo recibió una herramienta y una pregunta cuya respuesta no está en los datos de entrenamiento.\nEn vez de finalizar, devolvió <code>\"tool_calls\"</code> junto con el nombre de la función que debía\nejecutarse. Dichos valores cubren la mayoría de los casos habituales. Los demás valores indican situaciones que el\nmotor de ejecución debe gestionar, por ejemplo, reintentar la llamada o transferir la conversación\na una persona."
     },
     "rich.37cadcb11b30": {
       "type": "rich",
@@ -141,11 +131,6 @@
       "source": "<code>\"length\"</code> means the token budget ran out before the answer finished.",
       "value": "<code>\"length\"</code> significa que el presupuesto de tokens se agotó antes de completar la respuesta."
     },
-    "rich.914091fc2532": {
-      "type": "rich",
-      "source": "<strong>Count the steps on a genuinely tool-needing question.</strong>\n        \"How many minutes until 17:00 UTC?\" takes more than one tool call.\n        Run it a few times. Did the model call\n        <code>get_current_time</code> once, twice, or three times? Why\n        would a model re-call a tool whose output it already has,\n        and how would you discourage that in the system prompt?",
-      "value": "<strong>Cuenta los pasos en una pregunta que realmente necesita una herramienta.</strong>\n«¿Cuántos minutos faltan para las 17:00 UTC?» puede requerir más de una llamada a herramienta.\nEjecuta el ejemplo varias veces. ¿El modelo llama a <code>get_current_time</code> una, dos o tres\nveces? ¿Por qué volvería a solicitar una herramienta cuyo resultado ya figura en el historial?\n¿Cómo podrías evitarlo mediante el prompt del sistema?"
-    },
     "rich.9cf78b159479": {
       "type": "rich",
       "source": "\n    The flow is short: the model asks for the tool, the executor appends the timestamp as a\n    <code>tool</code>-role message, the model reads that timestamp, and the loop exits when\n    <code>finish_reason</code> reads <code>\"stop\"</code>.\n  ",
@@ -176,11 +161,6 @@
       "source": "<strong>Action</strong> is the tool call the harness executes.",
       "value": "La <strong>acción</strong> es la llamada a herramienta que ejecuta dicho motor."
     },
-    "rich.d7a22d027748": {
-      "type": "rich",
-      "source": "\n    <strong>What just happened inside the messages array.</strong><br>\n    The loop pushed four things into <code>state.messages</code>: <ul><li>the system\n    prompt (turn 0),</li><li>the user question (turn 1),</li><li>an assistant message with a\n    <code>tool_calls</code> field (turn 2, the request),</li><li>and a\n    <code>tool</code>-role message holding the function's return value (turn\n    3).</li></ul> The second LLM call read all four of those including the new tool result and\n    wrote the final answer. The growing array is the only \"memory\" this\n    agent has. If you saved that array to disk and reloaded it next week, the\n    model would resume the conversation without noticing the gap.\n  ",
-      "value": "<strong>Lo que acaba de suceder dentro del array de mensajes.</strong> <br>\nDurante el bucle se añadieron cuatro elementos a <code>state.messages</code>: <ul> <li>el prompt del sistema (turno 0);</li> <li>la pregunta del usuario (turno 1);</li> <li>un mensaje del asistente con un\ncampo <code>tool_calls</code> (turno 2, la solicitud);</li> <li>y un\nmensaje con el rol <code>tool</code> que contiene el valor devuelto por la función (turno\n3).</li> </ul> Una segunda llamada al modelo de lenguaje leyó los cuatro elementos, incluido el resultado de la herramienta, y\ngeneró la respuesta final. Este array creciente es la única «memoria» del agente. Si guardamos este array en\ndisco y lo volvemos a cargar una semana después, el modelo retomará la conversación sin percibir interrupción alguna."
-    },
     "rich.dab40f3dcbce": {
       "type": "rich",
       "source": "\n    Run the cell to build the panel, then chat with it. Pin one or more with\n    the <b>Pages</b> chips to ground every answer in them, or pin nothing and let the\n    agent choose what to read. The reply renders as markdown, with a chip for each source\n    the agent read so you can expand it to see the text it pulled back. Alongside the answer,\n    you also get the reasoning trace and the token usage. It remembers the conversation per chat.\n    Edit the cell and rerun to rebuild the artifact.\n  ",
@@ -190,11 +170,6 @@
       "type": "rich",
       "source": "<strong>Planning</strong> is the <code>finish_reason</code> router.",
       "value": "La <strong>planificación</strong> reside en el router que interpreta <code>finish_reason</code>."
-    },
-    "text.00b025711499": {
-      "type": "text",
-      "source": "(nothing)",
-      "value": "(nada)"
     },
     "text.026e6c091cf3": {
       "type": "text",
@@ -316,11 +291,6 @@
       "source": "The loop is unchanged. With a language model in the reasoning step, the agent reads tool results and acts by calling tools.",
       "value": "El bucle no cambia. Al incorporar un modelo de lenguaje en la etapa de razonamiento, el agente interpreta los resultados y actúa mediante llamadas a herramientas."
     },
-    "text.185d5444c22a": {
-      "type": "text",
-      "source": "Compare a direct answer with a tool request. Watch finish_reason change before building the complete loop.",
-      "value": "Compara dos llamadas al mismo modelo. La primera responde directamente; la segunda solicita una herramienta que debe ejecutar el código. Observa cómo cambia finish_reason. Esa herramienta anticipa el bucle completo que aparece más adelante."
-    },
     "text.1b12f21798d2": {
       "type": "text",
       "source": " Bound the loop so a confused agent cannot spin forever.",
@@ -355,18 +325,6 @@
       "source": "Think, act, observe, repeat. The turn exits the moment finish_reason is \"stop\".",
       "value": "Razonar, actuar, observar y repetir. El bucle termina cuando finish_reason vale \"stop\"."
     },
-    "text.263eb2e3d503": {
-      "type": "text",
-      "source": " \"stop\" means the answer is ready and the loop can exit",
-      "value": " \"stop\" means the answer is ready and the loop can exit",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.2744773dba26": {
-      "type": "text",
-      "source": " The model cannot run the tool itself; this preview asks your code to run it.",
-      "value": " The model cannot run the tool itself; this preview asks your code to run it.",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
     "text.288ec2e40f38": {
       "type": "text",
       "source": " state.userPrompt   = \"What time is it in UTC?\";",
@@ -394,12 +352,6 @@
       "type": "text",
       "source": "which page, e.g. 01b-react",
       "value": "which page, e.g. 01b-react",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.2cfc66a4bac0": {
-      "type": "text",
-      "source": " stops or asks for the tool on these same two questions.",
-      "value": " stops or asks for the tool on these same two questions.",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
     "text.2d08f3745b34": {
@@ -449,11 +401,6 @@
       "source": "finish_reason:",
       "value": "finish_reason:",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.36d507134134": {
-      "type": "text",
-      "source": " Optional visibility: uncomment to inspect the complete first response.",
-      "value": " Visibilidad opcional: descomenta para revisar la primera respuesta completa."
     },
     "text.3a417d05647e": {
       "type": "text",
@@ -660,12 +607,6 @@
       "value": "✗",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "text.6a6eb0c995bc": {
-      "type": "text",
-      "source": " \"tool_calls\" means the model is asking you to run a function",
-      "value": " \"tool_calls\" means the model is asking you to run a function",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
     "text.6c45cb72a36e": {
       "type": "text",
       "source": "stop",
@@ -681,12 +622,6 @@
       "type": "text",
       "source": " Pin each selected page in full so the chip reflects the actual context.",
       "value": " Pin each selected page in full so the chip reflects the actual context.",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.6ec7ac216303": {
-      "type": "text",
-      "source": " Call 1 · no tools offered. The model can answer, so it stops on its own.",
-      "value": " Call 1 · no tools offered. The model can answer, so it stops on its own.",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
     "text.761b7ad8ad43": {
@@ -727,12 +662,6 @@
       "type": "text",
       "source": "What time is it right now in UTC?",
       "value": "What time is it right now in UTC?",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.8060fc09ef01": {
-      "type": "text",
-      "source": " MODEL is the swappable brain. Change it and rerun to see whether a stronger model",
-      "value": " MODEL is the swappable brain. Change it and rerun to see whether a stronger model",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
     "text.850d8ef32ee1": {
@@ -850,18 +779,6 @@
       "value": "🔧",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "text.aa85ebc76614": {
-      "type": "text",
-      "source": " reasoning models think first; leave room past reasoning_content",
-      "value": " reasoning models think first; leave room past reasoning_content",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.aa9c9c97480a": {
-      "type": "text",
-      "source": "(used its whole budget thinking; raise max_tokens)",
-      "value": "(used its whole budget thinking; raise max_tokens)",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
     "text.ace774147c7e": {
       "type": "text",
       "source": "The complete ReAct loop, built from scratch",
@@ -938,11 +855,6 @@
       "value": "./vendor/langchain-1.4.7.esm.js",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "text.c3b7187e7262": {
-      "type": "text",
-      "source": " log.details(\"call 1 raw response\", r1);",
-      "value": " log.details(\"respuesta 1 sin procesar\", r1);"
-    },
     "text.c618570e5e70": {
       "type": "text",
       "source": "🔧 read page · ",
@@ -953,12 +865,6 @@
       "type": "text",
       "source": "error",
       "value": "error",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.ca32d7f2daac": {
-      "type": "text",
-      "source": " Call 2 · offer one tool and ask for something the model cannot know from training data.",
-      "value": " Call 2 · offer one tool and ask for something the model cannot know from training data.",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
     "text.ccc143876d1c": {
@@ -1017,11 +923,6 @@
       "value": "agent",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "text.d56573cb0730": {
-      "type": "text",
-      "source": "it asked you to run:",
-      "value": "el modelo pidió ejecutar:"
-    },
     "text.d9bda0c06ee1": {
       "type": "text",
       "source": "The same loop, prebuilt and pointed at this course",
@@ -1060,11 +961,6 @@
       "source": "course-wide question (\\\\",
       "value": "course-wide question (\\\\",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.e3ec162f8c8a": {
-      "type": "text",
-      "source": "call 2 · one tool offered, on a question training data cannot answer",
-      "value": "llamada 2 · una herramienta disponible para una pregunta que los datos de entrenamiento no pueden responder"
     },
     "text.e632b7095b0b": {
       "type": "text",
@@ -1143,6 +1039,158 @@
       "source": "tools",
       "value": "tools",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
+    },
+    "rich.04b481fa123f": {
+      "type": "rich",
+      "source": "\n    Every chat-completions response carries a <code>finish_reason</code>\n    field that tells you why the model stopped generating. Inside an agent\n    loop, read it alongside the response content and tool requests to decide what to do next:\n    run a tool, return the answer to the user, or handle an error. Before reading\n    what its values mean, make two calls and compare their replies.\n  ",
+      "value": "Cada respuesta de Chat Completions incluye <code>finish_reason</code>, que indica por qué el modelo dejó de generar. En el bucle del agente, lee ese campo junto con el contenido y las solicitudes de herramientas para decidir si ejecutar una herramienta, devolver la respuesta o gestionar un error. Antes de estudiar sus valores, realiza dos llamadas y compara las respuestas."
+    },
+    "rich.d503e5a1f6fe": {
+      "type": "rich",
+      "source": "\n    The first call offers no tools. In the second, the model is offered a tool and asked\n    for the current time. It still chooses whether to request the clock tool. Compare the displayed questions, replies, and\n    <code>finish_reason</code>. If both calls return <code>\"stop\"</code>, inspect the\n    second reply: did it admit it cannot check the time, or give an unsupported answer?\n    Change the model or question and rerun. A tool request names work for your code;\n    this preview does not execute it.\n  ",
+      "value": "La primera llamada no ofrece herramientas. En la segunda, se ofrece una herramienta al modelo y se le pregunta la hora actual. El modelo decide si solicita el reloj. Compara las preguntas, las respuestas y <code>finish_reason</code>. Si ambas devuelven <code>\"stop\"</code>, revisa la segunda respuesta: ¿admite que no puede consultar la hora o da una respuesta sin comprobarla? Cambia el modelo o la pregunta y vuelve a ejecutar. Una solicitud de herramienta indica trabajo para tu código; esta vista previa no lo ejecuta."
+    },
+    "rich.71d5f7e1b268": {
+      "type": "rich",
+      "source": "\n    <strong>What just happened inside the messages array.</strong><br>\n    When the model requests the clock, the loop adds these turns to <code>state.messages</code>: <ul><li>the system\n    prompt (turn 0),</li><li>the user question (turn 1),</li><li>an assistant message with a\n    <code>tool_calls</code> field (turn 2, the request),</li><li>and a\n    <code>tool</code>-role message holding the function's return value (turn\n    3).</li></ul> The second LLM call read all four of those including the new tool result and\n    wrote the final answer. The growing array is the only \"memory\" this\n    agent has. If you saved that array to disk and reloaded it next week, the\n    model would resume the conversation without noticing the gap.\n  ",
+      "value": "<strong>Lo que acaba de suceder dentro del array de mensajes.</strong> <br>\nCuando el modelo solicita el reloj, el bucle añade estos turnos a <code>state.messages</code>: <ul> <li>el prompt del sistema (turno 0);</li> <li>la pregunta del usuario (turno 1);</li> <li>un mensaje del asistente con un\ncampo <code>tool_calls</code> (turno 2, la solicitud);</li> <li>y un\nmensaje con el rol <code>tool</code> que contiene el valor devuelto por la función (turno\n3).</li> </ul> Una segunda llamada al modelo de lenguaje leyó los cuatro elementos, incluido el resultado de la herramienta, y\ngeneró la respuesta final. Este array creciente es la única «memoria» del agente. Si guardamos este array en\ndisco y lo volvemos a cargar una semana después, el modelo retomará la conversación sin percibir interrupción alguna."
+    },
+    "rich.925eff5b49ae": {
+      "type": "rich",
+      "source": "<strong>Count the steps on a genuinely tool-needing question.</strong>\n        \"How many minutes until 17:00 UTC?\" needs a clock reading and a calculation.\n        Run it a few times. Did the model call\n        <code>get_current_time</code> once, twice, or three times? Why\n        would a model re-call a tool whose output it already has,\n        and how would you discourage that in the system prompt?",
+      "value": "<strong>Cuenta los pasos de una pregunta que necesita una herramienta.</strong> \"¿Cuántos minutos faltan para las 17:00 UTC?\" necesita una lectura del reloj y un cálculo. Ejecútala varias veces. ¿El modelo llamó a <code>get_current_time</code> una, dos o tres veces? ¿Por qué volvería a solicitar un resultado que ya tiene? ¿Cómo cambiarías el prompt del sistema para evitarlo?"
+    },
+    "text.6998c813031f": {
+      "type": "text",
+      "source": "Compare two questions, the offered tools, and the actual replies. A model may answer or decline without requesting a tool.",
+      "value": "Compara las dos preguntas, las herramientas disponibles y las respuestas recibidas. Aunque no solicite ninguna herramienta, el modelo puede responder o indicar que no puede responder."
+    },
+    "text.99e1a8e15403": {
+      "type": "text",
+      "source": " On a custom endpoint, change the model in the connection card; that setting owns the route.",
+      "value": " En un endpoint personalizado, cambia el modelo en la tarjeta de conexión; esa configuración controla la ruta."
+    },
+    "text.408f13277d8d": {
+      "type": "text",
+      "source": "model:",
+      "value": "modelo:"
+    },
+    "text.1f5087db919c": {
+      "type": "text",
+      "source": "question",
+      "value": "pregunta"
+    },
+    "text.360cd27d23a6": {
+      "type": "text",
+      "source": "response model:",
+      "value": "modelo de la respuesta:"
+    },
+    "text.5db94652ba22": {
+      "type": "text",
+      "source": "reply:",
+      "value": "respuesta:"
+    },
+    "text.2d27e607c67d": {
+      "type": "text",
+      "source": "(no answer content; inspect the raw response)",
+      "value": "(sin contenido de respuesta; revisa la respuesta completa)"
+    },
+    "text.44a36db1abd1": {
+      "type": "text",
+      "source": "call 1 raw response",
+      "value": "respuesta completa de la llamada 1"
+    },
+    "text.6b9eac8f14cf": {
+      "type": "text",
+      "source": " Offering a tool lets the model request it; it does not execute the function.",
+      "value": " Ofrecer una herramienta permite que el modelo la solicite; no ejecuta la función."
+    },
+    "text.4809d1df83ab": {
+      "type": "text",
+      "source": " Optional visibility: inspect the exact schema offered to the model.",
+      "value": " Inspección opcional: revisa el esquema exacto que se ofrece al modelo."
+    },
+    "text.becc7f440ae3": {
+      "type": "text",
+      "source": " log.json(\"offered tool schema\", TOOLS);",
+      "value": " log.json(\"offered tool schema\", TOOLS);",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
+    },
+    "text.e18b187cecf8": {
+      "type": "text",
+      "source": "call 2 · get_current_time offered",
+      "value": "llamada 2 · get_current_time disponible"
+    },
+    "text.408f13277d8d~1": {
+      "type": "text",
+      "source": "model:",
+      "value": "modelo:"
+    },
+    "text.1f5087db919c~1": {
+      "type": "text",
+      "source": "question",
+      "value": "pregunta"
+    },
+    "text.360cd27d23a6~1": {
+      "type": "text",
+      "source": "response model:",
+      "value": "modelo de la respuesta:"
+    },
+    "text.5db94652ba22~1": {
+      "type": "text",
+      "source": "reply:",
+      "value": "respuesta:"
+    },
+    "text.b6d8f3ef94a9": {
+      "type": "text",
+      "source": "(no answer content)",
+      "value": "(sin contenido de respuesta)"
+    },
+    "text.dbacd9211eb0": {
+      "type": "text",
+      "source": "requested tools:",
+      "value": "herramientas solicitadas:"
+    },
+    "text.552e423045fc": {
+      "type": "text",
+      "source": "(none)",
+      "value": "(ninguna)"
+    },
+    "text.90dfb008f2c5": {
+      "type": "text",
+      "source": "call 2 raw response",
+      "value": "respuesta completa de la llamada 2"
+    },
+    "text.e869af251171": {
+      "type": "text",
+      "source": "No clock reading was taken. Inspect the reply, then change the question or model and compare.",
+      "value": "No se consultó el reloj. Revisa la respuesta, cambia la pregunta o el modelo y compara."
+    },
+    "text.c9d2fde3d3f2": {
+      "type": "text",
+      "source": " Optional comparison: ask QUESTION_2 to explicitly request the clock tool, then rerun.",
+      "value": " Comparación opcional: modifica QUESTION_2 para pedir explícitamente la herramienta de reloj y vuelve a ejecutar."
+    },
+    "text.408f13277d8d~2": {
+      "type": "text",
+      "source": "model:",
+      "value": "modelo:"
+    },
+    "text.1f5087db919c~2": {
+      "type": "text",
+      "source": "question",
+      "value": "pregunta"
+    },
+    "text.99de16babaa5": {
+      "type": "text",
+      "source": " Optional visibility: inspect the instruction guiding tool use.",
+      "value": " Inspección opcional: revisa la instrucción que guía el uso de herramientas."
+    },
+    "text.9024eab41188": {
+      "type": "text",
+      "source": " helpers.log.kv({ \"system prompt\": state.systemPrompt });",
+      "value": " helpers.log.kv({ \"system prompt\": state.systemPrompt });",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
     }
   }
 }

--- a/i18n/es/resources/web/nemoclaw/03a-kickstart.html.json
+++ b/i18n/es/resources/web/nemoclaw/03a-kickstart.html.json
@@ -393,11 +393,6 @@
       "source": "Direct model-only control. Change the saved course route above; this never reads, writes, or configures NemoClaw launchable values.",
       "value": "Control directo solo del modelo. Cambia arriba la ruta guardada del curso; esto nunca lee, escribe ni configura valores del launchable de NemoClaw."
     },
-    "text.17c76e3f9442": {
-      "type": "text",
-      "source": "Run 'Fetch matching models' first.",
-      "value": "Ejecuta primero «Obtener modelos coincidentes»."
-    },
     "text.185a2bfff807": {
       "type": "text",
       "source": " Optional visibility: uncomment to inspect the complete timing records.",
@@ -510,17 +505,6 @@
       "type": "text",
       "source": "Return here and enter the launchable URL. If this course is not served by the launchable,\n        paste the launchable's browser access session too.",
       "value": "Vuelve aquí e introduce la URL del launchable. Si el curso no se sirve desde el launchable,\n        pega también la sesión de acceso del navegador del launchable."
-    },
-    "text.2b50d1ad6eb6": {
-      "type": "text",
-      "source": " helpers.log.json(\"all model IDs\", data.map(model => model.id));",
-      "value": " helpers.log.json(\"todos los modelos\", data.map(model => model.id));"
-    },
-    "text.2bf548d80560": {
-      "type": "text",
-      "source": "glm",
-      "value": "glm",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
     },
     "text.2c40f2845cfc": {
       "type": "text",
@@ -879,11 +863,6 @@
       "value": "[DONE]",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
     },
-    "text.70ce88318f4e": {
-      "type": "text",
-      "source": " Optional visibility: uncomment to inspect every model ID before filtering.",
-      "value": " Visibilidad opcional: descomenta para revisar todos los identificadores antes del filtro."
-    },
     "text.7107f6329249": {
       "type": "text",
       "source": "the loop runs here",
@@ -1044,11 +1023,6 @@
       "source": "ms · ",
       "value": "ms · ",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
-    },
-    "text.93497aab615d": {
-      "type": "text",
-      "source": "No models matched filter: ",
-      "value": "Ningún modelo coincide con el filtro: "
     },
     "text.94aee8a89fe5": {
       "type": "text",
@@ -1335,12 +1309,6 @@
       "value": "models.list",
       "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
     },
-    "text.cd155903dfae": {
-      "type": "text",
-      "source": "120b",
-      "value": "120b",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
-    },
     "text.cdb4ee2aea69": {
       "type": "text",
       "source": ".",
@@ -1438,12 +1406,6 @@
       "source": "Authenticates the /cli/gateway WebSocket with operator.admin and stores a call() helper so later nodes reuse the connection.",
       "value": "Abre un WebSocket en /cli/gateway, responde al frame de desafío del servidor con la credencial operator.admin y guarda un helper call() en el estado. Los nodos siguientes podrán enviar solicitudes tipadas sin repetir el intercambio inicial."
     },
-    "text.e1517be14d06": {
-      "type": "text",
-      "source": "minimax",
-      "value": "minimax",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
-    },
     "text.e3ee9fe2c8e7": {
       "type": "text",
       "source": " · hit max_tokens",
@@ -1459,12 +1421,6 @@
       "type": "text",
       "source": "code bridge",
       "value": "el puente de código"
-    },
-    "text.e4f9c522e1c8": {
-      "type": "text",
-      "source": "kimi",
-      "value": "kimi",
-      "untranslated": "kept English: the reviewed es-ES overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
     },
     "text.e6e1d0a85eea": {
       "type": "text",
@@ -1580,6 +1536,69 @@
       "type": "text",
       "source": "No API key saved. Go to the course home and save the endpoint and key first.",
       "value": "No hay una clave de API guardada. Ve a la página inicial del curso y guarda primero el endpoint y la clave."
+    },
+    "text.0a07f6594619~2": {
+      "type": "text",
+      "source": ", ",
+      "value": ", ",
+      "untranslated": "Model-list delimiter."
+    },
+    "text.0f9cde8d8684": {
+      "type": "text",
+      "source": "prompt:",
+      "value": "prompt:",
+      "untranslated": "Established technical term prompt used in this locale."
+    },
+    "text.26bc854fbcb8": {
+      "type": "text",
+      "source": "Connection changed. Rerun Fetch matching models before measuring.",
+      "value": "La conexión ha cambiado. Repite la consulta de modelos antes de medir."
+    },
+    "text.29367fb9bc12": {
+      "type": "text",
+      "source": " Start with the configured model; edit using the catalog IDs below.",
+      "value": " Empieza con el modelo configurado; edita el filtro usando los ID del catálogo de abajo."
+    },
+    "text.7449100a979f": {
+      "type": "text",
+      "source": "No models matched. Choose an ID from available model IDs, edit FILTER, and rerun discovery.",
+      "value": "Ningún modelo coincide. Elige un ID de los modelos disponibles, edita FILTER y repite la consulta."
+    },
+    "text.7ba81713b6a9": {
+      "type": "text",
+      "source": " A failed discovery must not reuse models from an earlier run.",
+      "value": " Si falla la consulta, no reutilices modelos de una ejecución anterior."
+    },
+    "text.82d65f6c7bcc": {
+      "type": "text",
+      "source": "available model IDs",
+      "value": "ID de los modelos disponibles"
+    },
+    "text.8967a0229e67": {
+      "type": "text",
+      "source": "filter:",
+      "value": "filtro:"
+    },
+    "text.d08f12eafde7": {
+      "type": "text",
+      "source": "Fetch matching models must return at least one model. Inspect its catalog and filter, then rerun it.",
+      "value": "La consulta de modelos debe devolver al menos un modelo. Revisa el catálogo y el filtro, y vuelve a ejecutarla."
+    },
+    "text.e01ccf75a80a": {
+      "type": "text",
+      "source": "models:",
+      "value": "modelos:"
+    },
+    "text.ba3981b425bd": {
+      "type": "text",
+      "source": " Optional visibility: inspect the complete catalog entries.",
+      "value": " Inspección opcional: revisa las entradas completas del catálogo."
+    },
+    "text.d72346306aa8": {
+      "type": "text",
+      "source": " helpers.log.json(\"catalog response\", { data });",
+      "value": " helpers.log.json(\"catalog response\", { data });",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
     }
   }
 }

--- a/i18n/pt/localization_state.json
+++ b/i18n/pt/localization_state.json
@@ -219,8 +219,8 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "target_sha256": "e6c17106fe093770ec584baddd8189a98635f04dfdbd55b94049ac472ef2e14e",
+      "source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "target_sha256": "b4a0280b17b01920b66363ee762d44450ca1f003673200641bea5d0ecca719d8",
       "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/03b-openclaw.html": {

--- a/i18n/pt/localization_state.json
+++ b/i18n/pt/localization_state.json
@@ -44,7 +44,8 @@
     "text.b2eef2ab0d7f": "Reviewed Portuguese spells out ' mensagens' on 01a-loop and retains the compact trace abbreviation ' msgs' on 02c-deep.",
     "text.bef9d85df8ea": "'Selected: ' appears twice in web/index.html. The reviewed Portuguese overlay translates the language-picker occurrence as 'Selecionado: ' and leaves the second picker's occurrence in English, so the page ships both.",
     "text.efefc15c24ee": "Reviewed Portuguese localizes one 04a-safety empty-output path as '(sem saída)' while the other 04a path and both 04b terminal paths retain '(no output)'.",
-    "text.f612a61bab20": "Reviewed Portuguese retains the English agent-name hint on 03b-openclaw and localizes the same source on 03c-always-on."
+    "text.f612a61bab20": "Reviewed Portuguese retains the English agent-name hint on 03b-openclaw and localizes the same source on 03c-always-on.",
+    "text.1f5087db919c": "Codex reviewed this distinction at the maintainer's request: 01b-react translates the learner-visible log label 'question' as 'pergunta'; 01c-tools and 02b-rag retain 'question' as an executable tool-schema field name."
   },
   "asset_reviews": {
     "web/nemoclaw/assets/figures/01a-agent-environment.svg": {
@@ -188,10 +189,10 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/01b-react.html": {
-      "source_sha256": "99e02192657730a88ed08262938b92c7da8175bcec37cc45e6471f2937b595f0",
-      "translation_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "target_sha256": "be078c7554fc273875e7de58c6191efcaae9b454df7e40fb2c6d7815d08dc7fc",
-      "reviewed_on": "2026-09-02"
+      "source_sha256": "8cffc7082907c8e65db71a82677f6a1d190fcd59a7f00e32e505e4d0060689d0",
+      "translation_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "target_sha256": "2b83a9c44bd5241a015fad5c4ec3fa274c4e560dfed890a3c9c7e00aaafe2848",
+      "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/01c-tools.html": {
       "source_sha256": "2df9970a5768081b414813d8a79bd937f82820c318d28f8e26894977d3ddf503",
@@ -218,9 +219,9 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "target_sha256": "364056350c3d84854125907212e4a9cf9883335d5738115b2ec4e4d7eceb5e21",
-      "reviewed_on": "2026-08-14"
+      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "target_sha256": "e6c17106fe093770ec584baddd8189a98635f04dfdbd55b94049ac472ef2e14e",
+      "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/03b-openclaw.html": {
       "source_sha256": "0cda0d39d34e71f9831f39741062f771568f021e2784058c7929bcb619dbf0e3",

--- a/i18n/pt/resources/web/nemoclaw/01b-react.html.json
+++ b/i18n/pt/resources/web/nemoclaw/01b-react.html.json
@@ -91,11 +91,6 @@
       "value": "(tool \"\\${name}\" not found)",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "rich.0a886834e9f1": {
-      "type": "rich",
-      "source": "\n    Every chat-completions response carries a <code>finish_reason</code>\n    field that tells you why the model stopped generating. Inside an agent\n    loop, this is the only signal you need to decide what to do next:\n    run a tool, return the answer to the user, or handle an error. Before reading\n    what its values mean, make two calls and watch the field change.\n  ",
-      "value": "\n Todas as respostas de chat-completions carregam um campo <code>finish_reason</code>\n que informa por que o modelo parou de gerar. Dentro de um ciclo de agente,\n este é o único sinal de que você precisa para decidir o que fazer em seguida:\n executar uma ferramenta, retornar a resposta ao usuário ou lidar com um erro. Antes de ler\n o que seus valores significam, faça duas chamadas e observe o campo mudar.\n "
-    },
     "rich.1cbfc5ef05f8": {
       "type": "rich",
       "source": "<code>\"stop\"</code> means the model has written its final answer and the loop can return <code>content</code> to the user.",
@@ -105,11 +100,6 @@
       "type": "rich",
       "source": "<strong>Memory</strong> is the <code>messages[]</code> array.",
       "value": "<strong>Memória</strong> é o array <code>messages[]</code>."
-    },
-    "rich.32ec8d5bb853": {
-      "type": "rich",
-      "source": "\n    The first call answered on its own and came back <code>\"stop\"</code>. The second was\n    offered a tool and asked for something training data cannot supply, so instead of stopping\n    it came back <code>\"tool_calls\"</code>, handing your code the name of the function to run.\n    Those two values cover the common branching. The rest signal trouble that routes the loop\n    into a fallback harness, where the agent might retry the call or hand the conversation off\n    to a human.\n  ",
-      "value": "\n A primeira chamada respondeu sozinha e retornou <code>\"stop\"</code>. A segunda recebeu\n uma ferramenta e uma pergunta que os dados de treinamento não podem responder. Em vez de parar,\n ela retornou <code>\"tool_calls\"</code>, entregando ao código o nome da função a executar.\n Esses dois valores cobrem a ramificação comum. O restante sinaliza problemas que roteiam o ciclo\n para um fluxo de fallback do harness, no qual o agente pode tentar novamente a chamada ou passar a conversa para\n um humano.\n "
     },
     "rich.37cadcb11b30": {
       "type": "rich",
@@ -141,11 +131,6 @@
       "source": "<code>\"length\"</code> means the token budget ran out before the answer finished.",
       "value": "<code>\"length\"</code> significa que o orçamento de tokens esgotou antes que a resposta terminasse."
     },
-    "rich.914091fc2532": {
-      "type": "rich",
-      "source": "<strong>Count the steps on a genuinely tool-needing question.</strong>\n        \"How many minutes until 17:00 UTC?\" takes more than one tool call.\n        Run it a few times. Did the model call\n        <code>get_current_time</code> once, twice, or three times? Why\n        would a model re-call a tool whose output it already has,\n        and how would you discourage that in the system prompt?",
-      "value": "<strong>Conte as etapas em uma pergunta que realmente precisa de uma ferramenta.</strong>\n \"Quantos minutos até 17:00 UTC?\" leva mais de uma chamada de ferramenta.\n Execute algumas vezes. O modelo chamou\n <code>get_current_time</code> uma vez, duas vezes ou três vezes? Por que\n um modelo rechamaria uma ferramenta cuja saída ele já tem,\n e como você desencorajaria isso no prompt do sistema?"
-    },
     "rich.9cf78b159479": {
       "type": "rich",
       "source": "\n    The flow is short: the model asks for the tool, the executor appends the timestamp as a\n    <code>tool</code>-role message, the model reads that timestamp, and the loop exits when\n    <code>finish_reason</code> reads <code>\"stop\"</code>.\n  ",
@@ -176,11 +161,6 @@
       "source": "<strong>Action</strong> is the tool call the harness executes.",
       "value": "<strong>Ação</strong> é a chamada de ferramenta que o harness de execução executa."
     },
-    "rich.d7a22d027748": {
-      "type": "rich",
-      "source": "\n    <strong>What just happened inside the messages array.</strong><br>\n    The loop pushed four things into <code>state.messages</code>: <ul><li>the system\n    prompt (turn 0),</li><li>the user question (turn 1),</li><li>an assistant message with a\n    <code>tool_calls</code> field (turn 2, the request),</li><li>and a\n    <code>tool</code>-role message holding the function's return value (turn\n    3).</li></ul> The second LLM call read all four of those including the new tool result and\n    wrote the final answer. The growing array is the only \"memory\" this\n    agent has. If you saved that array to disk and reloaded it next week, the\n    model would resume the conversation without noticing the gap.\n  ",
-      "value": "\n <strong>O que acabou de acontecer dentro do array de mensagens.</strong><br>\n O ciclo adicionou quatro itens a <code>state.messages</code>: <ul><li>o prompt do sistema (turno 0),</li><li>a pergunta do usuário (turno 1),</li><li>uma mensagem de assistente com um\n campo <code>tool_calls</code> (turno 2, a solicitação),</li><li>e uma\n mensagem com o papel <code>tool</code> que contém o valor de retorno da função (turno\n 3).</li></ul> A segunda chamada do LLM leu todas as quatro, incluindo o novo resultado da ferramenta, e\n escreveu a resposta final. O array crescente é a única \"memória\" que este\n agente tem. Se você salvar esse array em disco e recarregá-lo na semana seguinte, o\n modelo retomará a conversa sem notar a lacuna.\n "
-    },
     "rich.dab40f3dcbce": {
       "type": "rich",
       "source": "\n    Run the cell to build the panel, then chat with it. Pin one or more with\n    the <b>Pages</b> chips to ground every answer in them, or pin nothing and let the\n    agent choose what to read. The reply renders as markdown, with a chip for each source\n    the agent read so you can expand it to see the text it pulled back. Alongside the answer,\n    you also get the reasoning trace and the token usage. It remembers the conversation per chat.\n    Edit the cell and rerun to rebuild the artifact.\n  ",
@@ -190,12 +170,6 @@
       "type": "rich",
       "source": "<strong>Planning</strong> is the <code>finish_reason</code> router.",
       "value": "<strong>Planejamento</strong> é o roteador <code>finish_reason</code>."
-    },
-    "text.00b025711499": {
-      "type": "text",
-      "source": "(nothing)",
-      "value": "(nothing)",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
     "text.026e6c091cf3": {
       "type": "text",
@@ -317,11 +291,6 @@
       "source": "The loop is unchanged. With a language model in the reasoning step, the agent reads tool results and acts by calling tools.",
       "value": "O ciclo permanece o mesmo. Com um grande modelo de linguagem na etapa de raciocínio, o agente lê os resultados e age chamando ferramentas."
     },
-    "text.185d5444c22a": {
-      "type": "text",
-      "source": "Compare a direct answer with a tool request. Watch finish_reason change before building the complete loop.",
-      "value": "Compare duas chamadas ao mesmo modelo. A primeira responde diretamente; a segunda solicita uma ferramenta que o seu código deve executar. Observe como finish_reason muda entre elas. Essa ferramenta é uma prévia do ciclo completo abaixo."
-    },
     "text.1b12f21798d2": {
       "type": "text",
       "source": " Bound the loop so a confused agent cannot spin forever.",
@@ -356,18 +325,6 @@
       "source": "Think, act, observe, repeat. The turn exits the moment finish_reason is \"stop\".",
       "value": "Pense, aja, observe, repita. O ciclo termina quando finish_reason é \"stop\"."
     },
-    "text.263eb2e3d503": {
-      "type": "text",
-      "source": " \"stop\" means the answer is ready and the loop can exit",
-      "value": " \"stop\" means the answer is ready and the loop can exit",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.2744773dba26": {
-      "type": "text",
-      "source": " The model cannot run the tool itself; this preview asks your code to run it.",
-      "value": " The model cannot run the tool itself; this preview asks your code to run it.",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
     "text.288ec2e40f38": {
       "type": "text",
       "source": " state.userPrompt   = \"What time is it in UTC?\";",
@@ -395,12 +352,6 @@
       "type": "text",
       "source": "which page, e.g. 01b-react",
       "value": "which page, e.g. 01b-react",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.2cfc66a4bac0": {
-      "type": "text",
-      "source": " stops or asks for the tool on these same two questions.",
-      "value": " stops or asks for the tool on these same two questions.",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
     "text.2d08f3745b34": {
@@ -450,11 +401,6 @@
       "source": "finish_reason:",
       "value": "finish_reason:",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.36d507134134": {
-      "type": "text",
-      "source": " Optional visibility: uncomment to inspect the complete first response.",
-      "value": " Visibilidade opcional: remova o comentário para inspecionar a primeira resposta completa."
     },
     "text.3a417d05647e": {
       "type": "text",
@@ -661,12 +607,6 @@
       "value": "✗",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "text.6a6eb0c995bc": {
-      "type": "text",
-      "source": " \"tool_calls\" means the model is asking you to run a function",
-      "value": " \"tool_calls\" means the model is asking you to run a function",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
     "text.6c45cb72a36e": {
       "type": "text",
       "source": "stop",
@@ -683,12 +623,6 @@
       "type": "text",
       "source": " Pin each selected page in full so the chip reflects the actual context.",
       "value": " Pin each selected page in full so the chip reflects the actual context.",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.6ec7ac216303": {
-      "type": "text",
-      "source": " Call 1 · no tools offered. The model can answer, so it stops on its own.",
-      "value": " Call 1 · no tools offered. The model can answer, so it stops on its own.",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
     "text.761b7ad8ad43": {
@@ -729,12 +663,6 @@
       "type": "text",
       "source": "What time is it right now in UTC?",
       "value": "What time is it right now in UTC?",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.8060fc09ef01": {
-      "type": "text",
-      "source": " MODEL is the swappable brain. Change it and rerun to see whether a stronger model",
-      "value": " MODEL is the swappable brain. Change it and rerun to see whether a stronger model",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
     "text.850d8ef32ee1": {
@@ -855,18 +783,6 @@
       "value": "🔧",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "text.aa85ebc76614": {
-      "type": "text",
-      "source": " reasoning models think first; leave room past reasoning_content",
-      "value": " reasoning models think first; leave room past reasoning_content",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.aa9c9c97480a": {
-      "type": "text",
-      "source": "(used its whole budget thinking; raise max_tokens)",
-      "value": "(used its whole budget thinking; raise max_tokens)",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
     "text.ace774147c7e": {
       "type": "text",
       "source": "The complete ReAct loop, built from scratch",
@@ -944,11 +860,6 @@
       "value": "./vendor/langchain-1.4.7.esm.js",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "text.c3b7187e7262": {
-      "type": "text",
-      "source": " log.details(\"call 1 raw response\", r1);",
-      "value": " log.details(\"resposta 1 bruta\", r1);"
-    },
     "text.c618570e5e70": {
       "type": "text",
       "source": "🔧 read page · ",
@@ -959,12 +870,6 @@
       "type": "text",
       "source": "error",
       "value": "error",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.ca32d7f2daac": {
-      "type": "text",
-      "source": " Call 2 · offer one tool and ask for something the model cannot know from training data.",
-      "value": " Call 2 · offer one tool and ask for something the model cannot know from training data.",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
     "text.ccc143876d1c": {
@@ -1024,11 +929,6 @@
       "value": "agent",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
     },
-    "text.d56573cb0730": {
-      "type": "text",
-      "source": "it asked you to run:",
-      "value": "ela solicitou que você executasse:"
-    },
     "text.d9bda0c06ee1": {
       "type": "text",
       "source": "The same loop, prebuilt and pointed at this course",
@@ -1067,11 +967,6 @@
       "source": "course-wide question (\\\\",
       "value": "course-wide question (\\\\",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
-    },
-    "text.e3ec162f8c8a": {
-      "type": "text",
-      "source": "call 2 · one tool offered, on a question training data cannot answer",
-      "value": "chamada 2 · uma ferramenta oferecida, em uma pergunta que os dados de treinamento não podem responder"
     },
     "text.e632b7095b0b": {
       "type": "text",
@@ -1150,6 +1045,158 @@
       "source": "tools",
       "value": "tools",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/01b-react.html carries the canonical source at this unit unchanged"
+    },
+    "rich.04b481fa123f": {
+      "type": "rich",
+      "source": "\n    Every chat-completions response carries a <code>finish_reason</code>\n    field that tells you why the model stopped generating. Inside an agent\n    loop, read it alongside the response content and tool requests to decide what to do next:\n    run a tool, return the answer to the user, or handle an error. Before reading\n    what its values mean, make two calls and compare their replies.\n  ",
+      "value": "Cada resposta de Chat Completions inclui <code>finish_reason</code>, que indica por que o modelo parou de gerar. No ciclo do agente, leia esse campo junto com o conteúdo e as solicitações de ferramentas para decidir se deve executar uma ferramenta, retornar a resposta ou tratar um erro. Antes de estudar os valores, faça duas chamadas e compare as respostas."
+    },
+    "rich.d503e5a1f6fe": {
+      "type": "rich",
+      "source": "\n    The first call offers no tools. In the second, the model is offered a tool and asked\n    for the current time. It still chooses whether to request the clock tool. Compare the displayed questions, replies, and\n    <code>finish_reason</code>. If both calls return <code>\"stop\"</code>, inspect the\n    second reply: did it admit it cannot check the time, or give an unsupported answer?\n    Change the model or question and rerun. A tool request names work for your code;\n    this preview does not execute it.\n  ",
+      "value": "A primeira chamada não oferece ferramentas. Na segunda, o modelo recebe uma ferramenta e uma pergunta sobre a hora atual. Ele decide se solicita o relógio. Compare as perguntas, as respostas e <code>finish_reason</code>. Se ambas retornarem <code>\"stop\"</code>, examine a segunda resposta: o modelo admite que não pode consultar a hora ou responde sem verificá-la? Altere o modelo ou a pergunta e execute novamente. Uma solicitação de ferramenta indica trabalho para seu código; esta prévia não o executa."
+    },
+    "rich.71d5f7e1b268": {
+      "type": "rich",
+      "source": "\n    <strong>What just happened inside the messages array.</strong><br>\n    When the model requests the clock, the loop adds these turns to <code>state.messages</code>: <ul><li>the system\n    prompt (turn 0),</li><li>the user question (turn 1),</li><li>an assistant message with a\n    <code>tool_calls</code> field (turn 2, the request),</li><li>and a\n    <code>tool</code>-role message holding the function's return value (turn\n    3).</li></ul> The second LLM call read all four of those including the new tool result and\n    wrote the final answer. The growing array is the only \"memory\" this\n    agent has. If you saved that array to disk and reloaded it next week, the\n    model would resume the conversation without noticing the gap.\n  ",
+      "value": "\n <strong>O que acabou de acontecer dentro do array de mensagens.</strong><br>\nQuando o modelo solicita o relógio, o ciclo adiciona estes turnos a <code>state.messages</code>: <ul><li>o prompt do sistema (turno 0),</li><li>a pergunta do usuário (turno 1),</li><li>uma mensagem de assistente com um\n campo <code>tool_calls</code> (turno 2, a solicitação),</li><li>e uma\n mensagem com o papel <code>tool</code> que contém o valor de retorno da função (turno\n 3).</li></ul> A segunda chamada do LLM leu todas as quatro, incluindo o novo resultado da ferramenta, e\n escreveu a resposta final. O array crescente é a única \"memória\" que este\n agente tem. Se você salvar esse array em disco e recarregá-lo na semana seguinte, o\n modelo retomará a conversa sem notar a lacuna.\n "
+    },
+    "rich.925eff5b49ae": {
+      "type": "rich",
+      "source": "<strong>Count the steps on a genuinely tool-needing question.</strong>\n        \"How many minutes until 17:00 UTC?\" needs a clock reading and a calculation.\n        Run it a few times. Did the model call\n        <code>get_current_time</code> once, twice, or three times? Why\n        would a model re-call a tool whose output it already has,\n        and how would you discourage that in the system prompt?",
+      "value": "<strong>Conte os passos de uma pergunta que precisa de uma ferramenta.</strong> \"Quantos minutos faltam para as 17:00 UTC?\" precisa de uma leitura do relógio e de um cálculo. Execute algumas vezes. O modelo chamou <code>get_current_time</code> uma, duas ou três vezes? Por que pediria novamente um resultado que já tem? Como você alteraria o prompt do sistema para evitar isso?"
+    },
+    "text.6998c813031f": {
+      "type": "text",
+      "source": "Compare two questions, the offered tools, and the actual replies. A model may answer or decline without requesting a tool.",
+      "value": "Compare as duas perguntas, as ferramentas disponíveis e as respostas recebidas. Mesmo sem solicitar uma ferramenta, o modelo pode responder ou informar que não consegue responder."
+    },
+    "text.99e1a8e15403": {
+      "type": "text",
+      "source": " On a custom endpoint, change the model in the connection card; that setting owns the route.",
+      "value": " Em um endpoint personalizado, altere o modelo no cartão de conexão; essa configuração controla a rota."
+    },
+    "text.408f13277d8d": {
+      "type": "text",
+      "source": "model:",
+      "value": "modelo:"
+    },
+    "text.1f5087db919c": {
+      "type": "text",
+      "source": "question",
+      "value": "pergunta"
+    },
+    "text.360cd27d23a6": {
+      "type": "text",
+      "source": "response model:",
+      "value": "modelo da resposta:"
+    },
+    "text.5db94652ba22": {
+      "type": "text",
+      "source": "reply:",
+      "value": "resposta:"
+    },
+    "text.2d27e607c67d": {
+      "type": "text",
+      "source": "(no answer content; inspect the raw response)",
+      "value": "(sem conteúdo de resposta; examine a resposta completa)"
+    },
+    "text.44a36db1abd1": {
+      "type": "text",
+      "source": "call 1 raw response",
+      "value": "resposta completa da chamada 1"
+    },
+    "text.6b9eac8f14cf": {
+      "type": "text",
+      "source": " Offering a tool lets the model request it; it does not execute the function.",
+      "value": " Oferecer uma ferramenta permite que o modelo a solicite; isso não executa a função."
+    },
+    "text.4809d1df83ab": {
+      "type": "text",
+      "source": " Optional visibility: inspect the exact schema offered to the model.",
+      "value": " Inspeção opcional: examine o esquema exato oferecido ao modelo."
+    },
+    "text.becc7f440ae3": {
+      "type": "text",
+      "source": " log.json(\"offered tool schema\", TOOLS);",
+      "value": " log.json(\"offered tool schema\", TOOLS);",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
+    },
+    "text.e18b187cecf8": {
+      "type": "text",
+      "source": "call 2 · get_current_time offered",
+      "value": "chamada 2 · get_current_time disponível"
+    },
+    "text.408f13277d8d~1": {
+      "type": "text",
+      "source": "model:",
+      "value": "modelo:"
+    },
+    "text.1f5087db919c~1": {
+      "type": "text",
+      "source": "question",
+      "value": "pergunta"
+    },
+    "text.360cd27d23a6~1": {
+      "type": "text",
+      "source": "response model:",
+      "value": "modelo da resposta:"
+    },
+    "text.5db94652ba22~1": {
+      "type": "text",
+      "source": "reply:",
+      "value": "resposta:"
+    },
+    "text.b6d8f3ef94a9": {
+      "type": "text",
+      "source": "(no answer content)",
+      "value": "(sem conteúdo de resposta)"
+    },
+    "text.dbacd9211eb0": {
+      "type": "text",
+      "source": "requested tools:",
+      "value": "ferramentas solicitadas:"
+    },
+    "text.552e423045fc": {
+      "type": "text",
+      "source": "(none)",
+      "value": "(nenhuma)"
+    },
+    "text.90dfb008f2c5": {
+      "type": "text",
+      "source": "call 2 raw response",
+      "value": "resposta completa da chamada 2"
+    },
+    "text.e869af251171": {
+      "type": "text",
+      "source": "No clock reading was taken. Inspect the reply, then change the question or model and compare.",
+      "value": "O relógio não foi consultado. Examine a resposta, altere a pergunta ou o modelo e compare."
+    },
+    "text.c9d2fde3d3f2": {
+      "type": "text",
+      "source": " Optional comparison: ask QUESTION_2 to explicitly request the clock tool, then rerun.",
+      "value": " Comparação opcional: altere QUESTION_2 para pedir explicitamente a ferramenta de relógio e execute novamente."
+    },
+    "text.408f13277d8d~2": {
+      "type": "text",
+      "source": "model:",
+      "value": "modelo:"
+    },
+    "text.1f5087db919c~2": {
+      "type": "text",
+      "source": "question",
+      "value": "pergunta"
+    },
+    "text.99de16babaa5": {
+      "type": "text",
+      "source": " Optional visibility: inspect the instruction guiding tool use.",
+      "value": " Inspeção opcional: examine a instrução que orienta o uso de ferramentas."
+    },
+    "text.9024eab41188": {
+      "type": "text",
+      "source": " helpers.log.kv({ \"system prompt\": state.systemPrompt });",
+      "value": " helpers.log.kv({ \"system prompt\": state.systemPrompt });",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
     }
   }
 }

--- a/i18n/pt/resources/web/nemoclaw/03a-kickstart.html.json
+++ b/i18n/pt/resources/web/nemoclaw/03a-kickstart.html.json
@@ -392,11 +392,6 @@
       "source": "Direct model-only control. Change the saved course route above; this never reads, writes, or configures NemoClaw launchable values.",
       "value": "Controle direto somente do modelo. Altere acima a rota salva do curso; isso nunca lê, grava ou configura valores do launchable do NemoClaw."
     },
-    "text.17c76e3f9442": {
-      "type": "text",
-      "source": "Run 'Fetch matching models' first.",
-      "value": "Execute primeiro 'Buscar modelos correspondentes'."
-    },
     "text.185a2bfff807": {
       "type": "text",
       "source": " Optional visibility: uncomment to inspect the complete timing records.",
@@ -508,17 +503,6 @@
       "type": "text",
       "source": "Return here and enter the launchable URL. If this course is not served by the launchable,\n        paste the launchable's browser access session too.",
       "value": "Volte para cá e informe a URL do launchable. Se o curso não for servido pelo launchable,\n        cole também a sessão de acesso do navegador do launchable."
-    },
-    "text.2b50d1ad6eb6": {
-      "type": "text",
-      "source": " helpers.log.json(\"all model IDs\", data.map(model => model.id));",
-      "value": " helpers.log.json(\"todos os modelos\", data.map(model => model.id));"
-    },
-    "text.2bf548d80560": {
-      "type": "text",
-      "source": "glm",
-      "value": "glm",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
     },
     "text.2c40f2845cfc": {
       "type": "text",
@@ -876,11 +860,6 @@
       "value": "[DONE]",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
     },
-    "text.70ce88318f4e": {
-      "type": "text",
-      "source": " Optional visibility: uncomment to inspect every model ID before filtering.",
-      "value": " Visibilidade opcional: remova o comentário para inspecionar todos os IDs antes do filtro."
-    },
     "text.7107f6329249": {
       "type": "text",
       "source": "the loop runs here",
@@ -1038,11 +1017,6 @@
       "source": "ms · ",
       "value": "ms · ",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
-    },
-    "text.93497aab615d": {
-      "type": "text",
-      "source": "No models matched filter: ",
-      "value": "Nenhum modelo corresponde aos filtros: "
     },
     "text.94aee8a89fe5": {
       "type": "text",
@@ -1321,12 +1295,6 @@
       "value": "models.list",
       "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
     },
-    "text.cd155903dfae": {
-      "type": "text",
-      "source": "120b",
-      "value": "120b",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
-    },
     "text.cdb4ee2aea69": {
       "type": "text",
       "source": ".",
@@ -1423,12 +1391,6 @@
       "source": "Authenticates the /cli/gateway WebSocket with operator.admin and stores a call() helper so later nodes reuse the connection.",
       "value": "Abra um WebSocket para /cli/gateway, responda ao frame de desafio do servidor com a credencial operator.admin e armazene um helper call() no estado. Assim, os nós seguintes podem enviar solicitações tipadas sem repetir a negociação inicial."
     },
-    "text.e1517be14d06": {
-      "type": "text",
-      "source": "minimax",
-      "value": "minimax",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
-    },
     "text.e3ee9fe2c8e7": {
       "type": "text",
       "source": " · hit max_tokens",
@@ -1443,12 +1405,6 @@
       "type": "text",
       "source": "code bridge",
       "value": "a ponte de código"
-    },
-    "text.e4f9c522e1c8": {
-      "type": "text",
-      "source": "kimi",
-      "value": "kimi",
-      "untranslated": "kept English: the reviewed pt-BR overlay of web/nemoclaw/03a-kickstart.html carries the canonical source at this unit unchanged"
     },
     "text.e6e1d0a85eea": {
       "type": "text",
@@ -1563,6 +1519,69 @@
       "type": "text",
       "source": "No API key saved. Go to the course home and save the endpoint and key first.",
       "value": "Nenhuma chave de API foi salva. Volte à página inicial e salve o endpoint e a chave."
+    },
+    "text.0a07f6594619~2": {
+      "type": "text",
+      "source": ", ",
+      "value": ", ",
+      "untranslated": "Model-list delimiter."
+    },
+    "text.0f9cde8d8684": {
+      "type": "text",
+      "source": "prompt:",
+      "value": "prompt:",
+      "untranslated": "Established technical term prompt used in this locale."
+    },
+    "text.26bc854fbcb8": {
+      "type": "text",
+      "source": "Connection changed. Rerun Fetch matching models before measuring.",
+      "value": "A conexão mudou. Repita a consulta de modelos antes de medir."
+    },
+    "text.29367fb9bc12": {
+      "type": "text",
+      "source": " Start with the configured model; edit using the catalog IDs below.",
+      "value": " Comece pelo modelo configurado; edite o filtro usando os IDs do catálogo abaixo."
+    },
+    "text.7449100a979f": {
+      "type": "text",
+      "source": "No models matched. Choose an ID from available model IDs, edit FILTER, and rerun discovery.",
+      "value": "Nenhum modelo corresponde ao filtro. Escolha um ID dos modelos disponíveis, edite FILTER e repita a consulta."
+    },
+    "text.7ba81713b6a9": {
+      "type": "text",
+      "source": " A failed discovery must not reuse models from an earlier run.",
+      "value": " Se a consulta falhar, não reutilize modelos de uma execução anterior."
+    },
+    "text.82d65f6c7bcc": {
+      "type": "text",
+      "source": "available model IDs",
+      "value": "IDs dos modelos disponíveis"
+    },
+    "text.8967a0229e67": {
+      "type": "text",
+      "source": "filter:",
+      "value": "filtro:"
+    },
+    "text.d08f12eafde7": {
+      "type": "text",
+      "source": "Fetch matching models must return at least one model. Inspect its catalog and filter, then rerun it.",
+      "value": "A consulta de modelos deve retornar pelo menos um modelo. Examine o catálogo e o filtro e execute novamente."
+    },
+    "text.e01ccf75a80a": {
+      "type": "text",
+      "source": "models:",
+      "value": "modelos:"
+    },
+    "text.ba3981b425bd": {
+      "type": "text",
+      "source": " Optional visibility: inspect the complete catalog entries.",
+      "value": " Inspeção opcional: examine as entradas completas do catálogo."
+    },
+    "text.d72346306aa8": {
+      "type": "text",
+      "source": " helpers.log.json(\"catalog response\", { data });",
+      "value": " helpers.log.json(\"catalog response\", { data });",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
     }
   }
 }

--- a/i18n/tw/localization_state.json
+++ b/i18n/tw/localization_state.json
@@ -31,7 +31,9 @@
     "web/nemoclaw/assets/figures/lethal-trifecta.svg",
     "web/nemoclaw/assets/figures/rag_arch_2021.svg"
   ],
-  "shared_key_variants": {},
+  "shared_key_variants": {
+    "text.1f5087db919c": "Codex reviewed this distinction at the maintainer's request: 01b-react translates the learner-visible log label 'question' as '問題'; 01c-tools and 02b-rag retain 'question' as an executable tool-schema field name."
+  },
   "asset_reviews": {
     "web/nemoclaw/assets/figures/01a-agent-environment.svg": {
       "source_sha256": "a3560220e745b1b834e67f4ba41f1ded4c143f60541f4b7fee3601a684652bde",
@@ -182,10 +184,10 @@
       "reviewed_on": "2026-09-03"
     },
     "web/nemoclaw/01b-react.html": {
-      "source_sha256": "99e02192657730a88ed08262938b92c7da8175bcec37cc45e6471f2937b595f0",
-      "translation_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "target_sha256": "b53e9c57d6697c51394255ed096e2054a83e3ea84e59074a862ef69135608503",
-      "reviewed_on": "2026-09-03"
+      "source_sha256": "8cffc7082907c8e65db71a82677f6a1d190fcd59a7f00e32e505e4d0060689d0",
+      "translation_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "target_sha256": "c536d75868fee552b7450ff7806674f82e5c05a66c6456182ae00234f62f2157",
+      "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/01c-tools.html": {
       "source_sha256": "2df9970a5768081b414813d8a79bd937f82820c318d28f8e26894977d3ddf503",
@@ -212,9 +214,9 @@
       "reviewed_on": "2026-09-03"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "target_sha256": "e7a1febe24970eee08af23b60c601af957823890c740d2689f4443a444e06235",
-      "reviewed_on": "2026-09-03"
+      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "target_sha256": "1b727bf6ef7676ddf53f293fff8ef2f2428f314df07130ac46aaf67248c4856c",
+      "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/03b-openclaw.html": {
       "source_sha256": "0cda0d39d34e71f9831f39741062f771568f021e2784058c7929bcb619dbf0e3",

--- a/i18n/tw/localization_state.json
+++ b/i18n/tw/localization_state.json
@@ -214,8 +214,8 @@
       "reviewed_on": "2026-09-03"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "target_sha256": "1b727bf6ef7676ddf53f293fff8ef2f2428f314df07130ac46aaf67248c4856c",
+      "source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "target_sha256": "169c4ea46a8e713512a6d73733d16522183028af378e2de0d9e1b5c357360138",
       "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/03b-openclaw.html": {

--- a/i18n/tw/resources/web/nemoclaw/01b-react.html.json
+++ b/i18n/tw/resources/web/nemoclaw/01b-react.html.json
@@ -89,11 +89,6 @@
       "source": "(tool \"\\${name}\" not found)",
       "value": "（未找到工具“\\${name}”）"
     },
-    "rich.0a886834e9f1": {
-      "type": "rich",
-      "source": "\n    Every chat-completions response carries a <code>finish_reason</code>\n    field that tells you why the model stopped generating. Inside an agent\n    loop, this is the only signal you need to decide what to do next:\n    run a tool, return the answer to the user, or handle an error. Before reading\n    what its values mean, make two calls and watch the field change.\n  ",
-      "value": "\n    每個聊天補全回應都包含一個 <code>finish_reason</code>\n    欄位，用於說明模型停止生成的原因。在代理程式迴圈中，您只需依據這一訊號決定下一步操作：執行工具、向使用者傳回答案或處理錯誤。在瞭解各個欄位值的含義之前，請先發起兩次呼叫並觀察該欄位的變化。\n  "
-    },
     "rich.1cbfc5ef05f8": {
       "type": "rich",
       "source": "<code>\"stop\"</code> means the model has written its final answer and the loop can return <code>content</code> to the user.",
@@ -103,11 +98,6 @@
       "type": "rich",
       "source": "<strong>Memory</strong> is the <code>messages[]</code> array.",
       "value": "<strong>記憶</strong>是 <code>messages[]</code> 陣列。"
-    },
-    "rich.32ec8d5bb853": {
-      "type": "rich",
-      "source": "\n    The first call answered on its own and came back <code>\"stop\"</code>. The second was\n    offered a tool and asked for something training data cannot supply, so instead of stopping\n    it came back <code>\"tool_calls\"</code>, handing your code the name of the function to run.\n    Those two values cover the common branching. The rest signal trouble that routes the loop\n    into a fallback harness, where the agent might retry the call or hand the conversation off\n    to a human.\n  ",
-      "value": "\n    第一次呼叫由模型自行作答，傳回了 <code>\"stop\"</code>。第二次呼叫向模型提供了工具，並要求獲取訓練資料無法提供的資訊，因此它沒有停止，而是傳回 <code>\"tool_calls\"</code>，將需要執行的函式名稱交給程式碼。這兩個值涵蓋了常見的分支情況。其餘值表示發生了問題，迴圈會轉入後備執行框架；代理程式可以在其中重試呼叫，或將對話轉交給人工處理。\n  "
     },
     "rich.37cadcb11b30": {
       "type": "rich",
@@ -139,11 +129,6 @@
       "source": "<code>\"length\"</code> means the token budget ran out before the answer finished.",
       "value": "<code>\"length\"</code> 表示答案尚未生成完畢，token 預算就已耗盡。"
     },
-    "rich.914091fc2532": {
-      "type": "rich",
-      "source": "<strong>Count the steps on a genuinely tool-needing question.</strong>\n        \"How many minutes until 17:00 UTC?\" takes more than one tool call.\n        Run it a few times. Did the model call\n        <code>get_current_time</code> once, twice, or three times? Why\n        would a model re-call a tool whose output it already has,\n        and how would you discourage that in the system prompt?",
-      "value": "<strong>針對一個確實需要工具的問題統計執行步數。</strong>\n        “距離 UTC 17:00 還有多少分鐘？”需要進行多次工具呼叫。多執行幾次。模型呼叫了 <code>get_current_time</code> 一次、兩次還是三次？為什麼模型會再次呼叫已經取得輸出的工具？您會如何在系統提示詞中抑制這種行為？"
-    },
     "rich.9cf78b159479": {
       "type": "rich",
       "source": "\n    The flow is short: the model asks for the tool, the executor appends the timestamp as a\n    <code>tool</code>-role message, the model reads that timestamp, and the loop exits when\n    <code>finish_reason</code> reads <code>\"stop\"</code>.\n  ",
@@ -174,11 +159,6 @@
       "source": "<strong>Action</strong> is the tool call the harness executes.",
       "value": "<strong>行動</strong>是執行框架執行的工具呼叫。"
     },
-    "rich.d7a22d027748": {
-      "type": "rich",
-      "source": "\n    <strong>What just happened inside the messages array.</strong><br>\n    The loop pushed four things into <code>state.messages</code>: <ul><li>the system\n    prompt (turn 0),</li><li>the user question (turn 1),</li><li>an assistant message with a\n    <code>tool_calls</code> field (turn 2, the request),</li><li>and a\n    <code>tool</code>-role message holding the function's return value (turn\n    3).</li></ul> The second LLM call read all four of those including the new tool result and\n    wrote the final answer. The growing array is the only \"memory\" this\n    agent has. If you saved that array to disk and reloaded it next week, the\n    model would resume the conversation without noticing the gap.\n  ",
-      "value": "\n    <strong>剛才 messages 陣列內部發生了什麼。</strong><br>\n    迴圈向 <code>state.messages</code> 中加入了四項：<ul><li>系統提示詞（第 0 輪），</li><li>使用者的問題（第 1 輪），</li><li>一條帶有 <code>tool_calls</code> 欄位的 assistant 訊息（第 2 輪，即請求），</li><li>以及一條儲存函式傳回值的 <code>tool</code> 角色訊息（第 3 輪）。</li></ul>第二次 LLM 呼叫讀取了這四項，包括新增的工具結果，然後生成最終答案。這個不斷增長的陣列就是該代理程式擁有的全部“記憶”。如果您將該陣列儲存到磁碟，並在下週重新載入，模型會繼續對話，甚至不會察覺中間曾中斷過。\n  "
-    },
     "rich.dab40f3dcbce": {
       "type": "rich",
       "source": "\n    Run the cell to build the panel, then chat with it. Pin one or more with\n    the <b>Pages</b> chips to ground every answer in them, or pin nothing and let the\n    agent choose what to read. The reply renders as markdown, with a chip for each source\n    the agent read so you can expand it to see the text it pulled back. Alongside the answer,\n    you also get the reasoning trace and the token usage. It remembers the conversation per chat.\n    Edit the cell and rerun to rebuild the artifact.\n  ",
@@ -188,11 +168,6 @@
       "type": "rich",
       "source": "<strong>Planning</strong> is the <code>finish_reason</code> router.",
       "value": "<strong>規劃</strong>是 <code>finish_reason</code> 路由邏輯。"
-    },
-    "text.00b025711499": {
-      "type": "text",
-      "source": "(nothing)",
-      "value": "（無）"
     },
     "text.026e6c091cf3": {
       "type": "text",
@@ -310,11 +285,6 @@
       "source": "The loop is unchanged. With a language model in the reasoning step, the agent reads tool results and acts by calling tools.",
       "value": "迴圈本身沒有變化。以語言模型執行推理步驟時，代理程式讀取工具結果，並透過呼叫工具採取行動。"
     },
-    "text.185d5444c22a": {
-      "type": "text",
-      "source": "Compare a direct answer with a tool request. Watch finish_reason change before building the complete loop.",
-      "value": "比較直接回答與工具請求。在建置完整迴圈之前，觀察 finish_reason 如何變化。"
-    },
     "text.1b12f21798d2": {
       "type": "text",
       "source": " Bound the loop so a confused agent cannot spin forever.",
@@ -346,18 +316,6 @@
       "source": "Think, act, observe, repeat. The turn exits the moment finish_reason is \"stop\".",
       "value": "思考、行動、觀察、重複。一旦 finish_reason 為 \"stop\"，當前輪次立即結束。"
     },
-    "text.263eb2e3d503": {
-      "type": "text",
-      "source": " \"stop\" means the answer is ready and the loop can exit",
-      "value": " \"stop\" means the answer is ready and the loop can exit",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
-    "text.2744773dba26": {
-      "type": "text",
-      "source": " The model cannot run the tool itself; this preview asks your code to run it.",
-      "value": " The model cannot run the tool itself; this preview asks your code to run it.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
     "text.288ec2e40f38": {
       "type": "text",
       "source": " state.userPrompt   = \"What time is it in UTC?\";",
@@ -385,12 +343,6 @@
       "type": "text",
       "source": "which page, e.g. 01b-react",
       "value": "要讀取的頁面，例如 01b-react"
-    },
-    "text.2cfc66a4bac0": {
-      "type": "text",
-      "source": " stops or asks for the tool on these same two questions.",
-      "value": " stops or asks for the tool on these same two questions.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.2d08f3745b34": {
       "type": "text",
@@ -433,12 +385,6 @@
       "type": "text",
       "source": "finish_reason:",
       "value": "finish_reason："
-    },
-    "text.36d507134134": {
-      "type": "text",
-      "source": " Optional visibility: uncomment to inspect the complete first response.",
-      "value": " Optional visibility: uncomment to inspect the complete first response.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.3a417d05647e": {
       "type": "text",
@@ -639,12 +585,6 @@
       "value": "✗",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.6a6eb0c995bc": {
-      "type": "text",
-      "source": " \"tool_calls\" means the model is asking you to run a function",
-      "value": " \"tool_calls\" means the model is asking you to run a function",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
     "text.6c45cb72a36e": {
       "type": "text",
       "source": "stop",
@@ -660,12 +600,6 @@
       "type": "text",
       "source": " Pin each selected page in full so the chip reflects the actual context.",
       "value": " Pin each selected page in full so the chip reflects the actual context.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
-    "text.6ec7ac216303": {
-      "type": "text",
-      "source": " Call 1 · no tools offered. The model can answer, so it stops on its own.",
-      "value": " Call 1 · no tools offered. The model can answer, so it stops on its own.",
       "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.761b7ad8ad43": {
@@ -706,12 +640,6 @@
       "type": "text",
       "source": "What time is it right now in UTC?",
       "value": "UTC 現在幾點？"
-    },
-    "text.8060fc09ef01": {
-      "type": "text",
-      "source": " MODEL is the swappable brain. Change it and rerun to see whether a stronger model",
-      "value": " MODEL is the swappable brain. Change it and rerun to see whether a stronger model",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.850d8ef32ee1": {
       "type": "text",
@@ -825,17 +753,6 @@
       "value": "🔧",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.aa85ebc76614": {
-      "type": "text",
-      "source": " reasoning models think first; leave room past reasoning_content",
-      "value": " reasoning models think first; leave room past reasoning_content",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
-    "text.aa9c9c97480a": {
-      "type": "text",
-      "source": "(used its whole budget thinking; raise max_tokens)",
-      "value": "（思考耗盡了全部預算；請提高 max_tokens）"
-    },
     "text.ace774147c7e": {
       "type": "text",
       "source": "The complete ReAct loop, built from scratch",
@@ -912,12 +829,6 @@
       "value": "./vendor/langchain-1.4.7.esm.js",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.c3b7187e7262": {
-      "type": "text",
-      "source": " log.details(\"call 1 raw response\", r1);",
-      "value": " log.details(\"call 1 raw response\", r1);",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
     "text.c618570e5e70": {
       "type": "text",
       "source": "🔧 read page · ",
@@ -928,12 +839,6 @@
       "source": "error",
       "value": "error",
       "untranslated": "kept English: exact executable code, protocol, punctuation, or interface literal"
-    },
-    "text.ca32d7f2daac": {
-      "type": "text",
-      "source": " Call 2 · offer one tool and ask for something the model cannot know from training data.",
-      "value": " Call 2 · offer one tool and ask for something the model cannot know from training data.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.ccc143876d1c": {
       "type": "text",
@@ -990,11 +895,6 @@
       "value": "agent",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.d56573cb0730": {
-      "type": "text",
-      "source": "it asked you to run:",
-      "value": "它要求您執行："
-    },
     "text.d9bda0c06ee1": {
       "type": "text",
       "source": "The same loop, prebuilt and pointed at this course",
@@ -1032,11 +932,6 @@
       "type": "text",
       "source": "course-wide question (\\\\",
       "value": "涉及整個課程的問題（\\\\"
-    },
-    "text.e3ec162f8c8a": {
-      "type": "text",
-      "source": "call 2 · one tool offered, on a question training data cannot answer",
-      "value": "呼叫 2 · 針對訓練資料無法回答的問題提供一個工具"
     },
     "text.e632b7095b0b": {
       "type": "text",
@@ -1112,6 +1007,163 @@
       "source": "tools",
       "value": "tools",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
+    },
+    "rich.04b481fa123f": {
+      "type": "rich",
+      "source": "\n    Every chat-completions response carries a <code>finish_reason</code>\n    field that tells you why the model stopped generating. Inside an agent\n    loop, read it alongside the response content and tool requests to decide what to do next:\n    run a tool, return the answer to the user, or handle an error. Before reading\n    what its values mean, make two calls and compare their replies.\n  ",
+      "value": "每個 Chat Completions 回應都包含 <code>finish_reason</code>，用來說明模型停止生成的原因。在代理程式迴圈中，將它與回應內容和工具請求一起檢查，決定執行工具、傳回回答或處理錯誤。在了解各個值之前，先發出兩次呼叫並比較回覆。"
+    },
+    "rich.d503e5a1f6fe": {
+      "type": "rich",
+      "source": "\n    The first call offers no tools. In the second, the model is offered a tool and asked\n    for the current time. It still chooses whether to request the clock tool. Compare the displayed questions, replies, and\n    <code>finish_reason</code>. If both calls return <code>\"stop\"</code>, inspect the\n    second reply: did it admit it cannot check the time, or give an unsupported answer?\n    Change the model or question and rerun. A tool request names work for your code;\n    this preview does not execute it.\n  ",
+      "value": "第一次呼叫不提供工具。第二次呼叫向模型提供工具並詢問目前時間。是否請求使用時鐘工具仍由模型決定。比較顯示的問題、回覆與 <code>finish_reason</code>。如果兩次都傳回 <code>\"stop\"</code>，請檢查第二則回覆：模型承認無法查詢時間，還是給出了未經驗證的回答？更換模型或問題後重新執行。工具請求只是指明需要程式碼執行的工作；此預覽不會執行工具。"
+    },
+    "rich.71d5f7e1b268": {
+      "type": "rich",
+      "source": "\n    <strong>What just happened inside the messages array.</strong><br>\n    When the model requests the clock, the loop adds these turns to <code>state.messages</code>: <ul><li>the system\n    prompt (turn 0),</li><li>the user question (turn 1),</li><li>an assistant message with a\n    <code>tool_calls</code> field (turn 2, the request),</li><li>and a\n    <code>tool</code>-role message holding the function's return value (turn\n    3).</li></ul> The second LLM call read all four of those including the new tool result and\n    wrote the final answer. The growing array is the only \"memory\" this\n    agent has. If you saved that array to disk and reloaded it next week, the\n    model would resume the conversation without noticing the gap.\n  ",
+      "value": "\n    <strong>剛才 messages 陣列內部發生了什麼。</strong><br>\n當模型請求時鐘時，迴圈會向 <code>state.messages</code> 中加入以下四項：<ul><li>系統提示詞（第 0 輪），</li><li>使用者的問題（第 1 輪），</li><li>一條帶有 <code>tool_calls</code> 欄位的 assistant 訊息（第 2 輪，即請求），</li><li>以及一條儲存函式傳回值的 <code>tool</code> 角色訊息（第 3 輪）。</li></ul>第二次 LLM 呼叫讀取了這四項，包括新增的工具結果，然後生成最終答案。這個不斷增長的陣列就是該代理程式擁有的全部“記憶”。如果您將該陣列儲存到磁碟，並在下週重新載入，模型會繼續對話，甚至不會察覺中間曾中斷過。\n  "
+    },
+    "rich.925eff5b49ae": {
+      "type": "rich",
+      "source": "<strong>Count the steps on a genuinely tool-needing question.</strong>\n        \"How many minutes until 17:00 UTC?\" needs a clock reading and a calculation.\n        Run it a few times. Did the model call\n        <code>get_current_time</code> once, twice, or three times? Why\n        would a model re-call a tool whose output it already has,\n        and how would you discourage that in the system prompt?",
+      "value": "<strong>統計需要工具的問題所用的步驟。</strong>「距離 17:00 UTC 還有多少分鐘？」需要讀取時鐘並進行計算。執行幾次，看看模型呼叫 <code>get_current_time</code> 一次、兩次或三次。為什麼模型會重複呼叫已取得結果的工具？您會如何修改系統提示詞來減少重複呼叫？"
+    },
+    "text.6998c813031f": {
+      "type": "text",
+      "source": "Compare two questions, the offered tools, and the actual replies. A model may answer or decline without requesting a tool.",
+      "value": "比較兩個問題、提供的工具與實際回覆。模型可能直接回答或表示無法回答，而不請求工具。"
+    },
+    "text.99e1a8e15403": {
+      "type": "text",
+      "source": " On a custom endpoint, change the model in the connection card; that setting owns the route.",
+      "value": " On a custom endpoint, change the model in the connection card; that setting owns the route.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.408f13277d8d": {
+      "type": "text",
+      "source": "model:",
+      "value": "模型："
+    },
+    "text.1f5087db919c": {
+      "type": "text",
+      "source": "question",
+      "value": "問題"
+    },
+    "text.360cd27d23a6": {
+      "type": "text",
+      "source": "response model:",
+      "value": "回應模型："
+    },
+    "text.5db94652ba22": {
+      "type": "text",
+      "source": "reply:",
+      "value": "回覆："
+    },
+    "text.2d27e607c67d": {
+      "type": "text",
+      "source": "(no answer content; inspect the raw response)",
+      "value": "（沒有回答內容；請查看原始回應）"
+    },
+    "text.44a36db1abd1": {
+      "type": "text",
+      "source": "call 1 raw response",
+      "value": "呼叫 1 的原始回應"
+    },
+    "text.6b9eac8f14cf": {
+      "type": "text",
+      "source": " Offering a tool lets the model request it; it does not execute the function.",
+      "value": " Offering a tool lets the model request it; it does not execute the function.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.4809d1df83ab": {
+      "type": "text",
+      "source": " Optional visibility: inspect the exact schema offered to the model.",
+      "value": " Optional visibility: inspect the exact schema offered to the model.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.becc7f440ae3": {
+      "type": "text",
+      "source": " log.json(\"offered tool schema\", TOOLS);",
+      "value": " log.json(\"offered tool schema\", TOOLS);",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
+    },
+    "text.e18b187cecf8": {
+      "type": "text",
+      "source": "call 2 · get_current_time offered",
+      "value": "呼叫 2 · 提供 get_current_time"
+    },
+    "text.408f13277d8d~1": {
+      "type": "text",
+      "source": "model:",
+      "value": "模型："
+    },
+    "text.1f5087db919c~1": {
+      "type": "text",
+      "source": "question",
+      "value": "問題"
+    },
+    "text.360cd27d23a6~1": {
+      "type": "text",
+      "source": "response model:",
+      "value": "回應模型："
+    },
+    "text.5db94652ba22~1": {
+      "type": "text",
+      "source": "reply:",
+      "value": "回覆："
+    },
+    "text.b6d8f3ef94a9": {
+      "type": "text",
+      "source": "(no answer content)",
+      "value": "（沒有回答內容）"
+    },
+    "text.dbacd9211eb0": {
+      "type": "text",
+      "source": "requested tools:",
+      "value": "請求的工具："
+    },
+    "text.552e423045fc": {
+      "type": "text",
+      "source": "(none)",
+      "value": "（無）"
+    },
+    "text.90dfb008f2c5": {
+      "type": "text",
+      "source": "call 2 raw response",
+      "value": "呼叫 2 的原始回應"
+    },
+    "text.e869af251171": {
+      "type": "text",
+      "source": "No clock reading was taken. Inspect the reply, then change the question or model and compare.",
+      "value": "尚未讀取時鐘。檢查回覆，再更換問題或模型並比較結果。"
+    },
+    "text.c9d2fde3d3f2": {
+      "type": "text",
+      "source": " Optional comparison: ask QUESTION_2 to explicitly request the clock tool, then rerun.",
+      "value": " Optional comparison: ask QUESTION_2 to explicitly request the clock tool, then rerun.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.408f13277d8d~2": {
+      "type": "text",
+      "source": "model:",
+      "value": "模型："
+    },
+    "text.1f5087db919c~2": {
+      "type": "text",
+      "source": "question",
+      "value": "問題"
+    },
+    "text.99de16babaa5": {
+      "type": "text",
+      "source": " Optional visibility: inspect the instruction guiding tool use.",
+      "value": " Optional visibility: inspect the instruction guiding tool use.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.9024eab41188": {
+      "type": "text",
+      "source": " helpers.log.kv({ \"system prompt\": state.systemPrompt });",
+      "value": " helpers.log.kv({ \"system prompt\": state.systemPrompt });",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
     }
   }
 }

--- a/i18n/tw/resources/web/nemoclaw/03a-kickstart.html.json
+++ b/i18n/tw/resources/web/nemoclaw/03a-kickstart.html.json
@@ -377,11 +377,6 @@
       "source": "← final chat frame",
       "value": "← 最終聊天幀"
     },
-    "text.17c76e3f9442": {
-      "type": "text",
-      "source": "Run 'Fetch matching models' first.",
-      "value": "請先執行“獲取匹配的模型”。"
-    },
     "text.185a2bfff807": {
       "type": "text",
       "source": " Optional visibility: uncomment to inspect the complete timing records.",
@@ -482,18 +477,6 @@
       "type": "text",
       "source": "Return here and enter the launchable URL. If this course is not served by the launchable,\n        paste the launchable's browser access session too.",
       "value": "傳回此頁面並輸入 launchable URL。如果本課程並非由 launchable 提供，還需貼上 launchable 的瀏覽器存取會話。"
-    },
-    "text.2b50d1ad6eb6": {
-      "type": "text",
-      "source": " helpers.log.json(\"all model IDs\", data.map(model => model.id));",
-      "value": " helpers.log.json(\"all model IDs\", data.map(model => model.id));",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
-    "text.2bf548d80560": {
-      "type": "text",
-      "source": "glm",
-      "value": "glm",
-      "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
     "text.2c40f2845cfc": {
       "type": "text",
@@ -843,12 +826,6 @@
       "value": "[DONE]",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.70ce88318f4e": {
-      "type": "text",
-      "source": " Optional visibility: uncomment to inspect every model ID before filtering.",
-      "value": " Optional visibility: uncomment to inspect every model ID before filtering.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
     "text.7107f6329249": {
       "type": "text",
       "source": "the loop runs here",
@@ -1013,11 +990,6 @@
       "type": "text",
       "source": "ms · ",
       "value": "毫秒 · "
-    },
-    "text.93497aab615d": {
-      "type": "text",
-      "source": "No models matched filter: ",
-      "value": "沒有模型符合篩選條件："
     },
     "text.94aee8a89fe5": {
       "type": "text",
@@ -1301,12 +1273,6 @@
       "value": "models.list",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.cd155903dfae": {
-      "type": "text",
-      "source": "120b",
-      "value": "120b",
-      "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
-    },
     "text.cdb4ee2aea69": {
       "type": "text",
       "source": ".",
@@ -1403,12 +1369,6 @@
       "source": "Authenticates the /cli/gateway WebSocket with operator.admin and stores a call() helper so later nodes reuse the connection.",
       "value": "使用 operator.admin 對 /cli/gateway WebSocket 進行身分驗證，並儲存 call() 輔助函式，供後續節點複用該連線。"
     },
-    "text.e1517be14d06": {
-      "type": "text",
-      "source": "minimax",
-      "value": "minimax",
-      "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
-    },
     "text.e3ee9fe2c8e7": {
       "type": "text",
       "source": " · hit max_tokens",
@@ -1424,12 +1384,6 @@
       "type": "text",
       "source": "code bridge",
       "value": "程式碼橋接層"
-    },
-    "text.e4f9c522e1c8": {
-      "type": "text",
-      "source": "kimi",
-      "value": "kimi",
-      "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
     "text.e6e1d0a85eea": {
       "type": "text",
@@ -1551,6 +1505,71 @@
       "type": "text",
       "source": "No API key saved. Go to the course home and save the endpoint and key first.",
       "value": "尚未儲存 API key。請先前往課程首頁，儲存 API 端點和金鑰。"
+    },
+    "text.0a07f6594619~2": {
+      "type": "text",
+      "source": ", ",
+      "value": ", ",
+      "untranslated": "Model-list delimiter."
+    },
+    "text.0f9cde8d8684": {
+      "type": "text",
+      "source": "prompt:",
+      "value": "提示："
+    },
+    "text.26bc854fbcb8": {
+      "type": "text",
+      "source": "Connection changed. Rerun Fetch matching models before measuring.",
+      "value": "連線已變更。請先重新執行模型探索步驟，再測量延遲。"
+    },
+    "text.29367fb9bc12": {
+      "type": "text",
+      "source": " Start with the configured model; edit using the catalog IDs below.",
+      "value": " Start with the configured model; edit using the catalog IDs below.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.7449100a979f": {
+      "type": "text",
+      "source": "No models matched. Choose an ID from available model IDs, edit FILTER, and rerun discovery.",
+      "value": "沒有符合條件的模型。請從可用模型 ID 中選擇一個，修改 FILTER，再重新執行探索步驟。"
+    },
+    "text.7ba81713b6a9": {
+      "type": "text",
+      "source": " A failed discovery must not reuse models from an earlier run.",
+      "value": " A failed discovery must not reuse models from an earlier run.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.82d65f6c7bcc": {
+      "type": "text",
+      "source": "available model IDs",
+      "value": "可用模型 ID"
+    },
+    "text.8967a0229e67": {
+      "type": "text",
+      "source": "filter:",
+      "value": "篩選條件："
+    },
+    "text.d08f12eafde7": {
+      "type": "text",
+      "source": "Fetch matching models must return at least one model. Inspect its catalog and filter, then rerun it.",
+      "value": "模型探索步驟必須傳回至少一個模型。請檢查目錄與篩選條件，再重新執行。"
+    },
+    "text.e01ccf75a80a": {
+      "type": "text",
+      "source": "models:",
+      "value": "模型："
+    },
+    "text.ba3981b425bd": {
+      "type": "text",
+      "source": " Optional visibility: inspect the complete catalog entries.",
+      "value": " Optional visibility: inspect the complete catalog entries.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.d72346306aa8": {
+      "type": "text",
+      "source": " helpers.log.json(\"catalog response\", { data });",
+      "value": " helpers.log.json(\"catalog response\", { data });",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
     }
   }
 }

--- a/i18n/zh/localization_state.json
+++ b/i18n/zh/localization_state.json
@@ -214,8 +214,8 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "target_sha256": "c7d2d7109ecd8994764694d52e3596be3a2f3083a24f1d5be29888c765095ef0",
+      "source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "target_sha256": "22fae2a0791a379e26e3f1f214d71783a819060ab5cf64aee6b47f829f2b5d21",
       "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/03b-openclaw.html": {

--- a/i18n/zh/localization_state.json
+++ b/i18n/zh/localization_state.json
@@ -31,7 +31,9 @@
     "web/nemoclaw/assets/figures/lethal-trifecta.svg",
     "web/nemoclaw/assets/figures/rag_arch_2021.svg"
   ],
-  "shared_key_variants": {},
+  "shared_key_variants": {
+    "text.1f5087db919c": "Codex reviewed this distinction at the maintainer's request: 01b-react translates the learner-visible log label 'question' as '问题'; 01c-tools and 02b-rag retain 'question' as an executable tool-schema field name."
+  },
   "asset_reviews": {
     "web/nemoclaw/assets/figures/01a-agent-environment.svg": {
       "source_sha256": "a3560220e745b1b834e67f4ba41f1ded4c143f60541f4b7fee3601a684652bde",
@@ -182,10 +184,10 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/01b-react.html": {
-      "source_sha256": "99e02192657730a88ed08262938b92c7da8175bcec37cc45e6471f2937b595f0",
-      "translation_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "target_sha256": "ed031333d20242cd89871e72aa6fe006bcdd30e1da52fce2b1b52248185639f7",
-      "reviewed_on": "2026-09-03"
+      "source_sha256": "8cffc7082907c8e65db71a82677f6a1d190fcd59a7f00e32e505e4d0060689d0",
+      "translation_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "target_sha256": "0b7f1faee9d0e75dcb24543eb3346bfa914d1d42a0513323b93c1c0ad36ef981",
+      "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/01c-tools.html": {
       "source_sha256": "2df9970a5768081b414813d8a79bd937f82820c318d28f8e26894977d3ddf503",
@@ -212,9 +214,9 @@
       "reviewed_on": "2026-09-02"
     },
     "web/nemoclaw/03a-kickstart.html": {
-      "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "target_sha256": "bab48c3bfde9b87a7b5cb281c092eef144b4ecd8f85aef27001b31fdd7b2ce68",
-      "reviewed_on": "2026-08-18"
+      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "target_sha256": "c7d2d7109ecd8994764694d52e3596be3a2f3083a24f1d5be29888c765095ef0",
+      "reviewed_on": "2026-09-10"
     },
     "web/nemoclaw/03b-openclaw.html": {
       "source_sha256": "0cda0d39d34e71f9831f39741062f771568f021e2784058c7929bcb619dbf0e3",

--- a/i18n/zh/resources/web/nemoclaw/01b-react.html.json
+++ b/i18n/zh/resources/web/nemoclaw/01b-react.html.json
@@ -89,11 +89,6 @@
       "source": "(tool \"\\${name}\" not found)",
       "value": "（未找到工具“\\${name}”）"
     },
-    "rich.0a886834e9f1": {
-      "type": "rich",
-      "source": "\n    Every chat-completions response carries a <code>finish_reason</code>\n    field that tells you why the model stopped generating. Inside an agent\n    loop, this is the only signal you need to decide what to do next:\n    run a tool, return the answer to the user, or handle an error. Before reading\n    what its values mean, make two calls and watch the field change.\n  ",
-      "value": "\n    每个聊天补全响应都包含一个 <code>finish_reason</code>\n    字段，用于说明模型停止生成的原因。在智能体循环中，您只需依据这一信号决定下一步操作：运行工具、向用户返回答案或处理错误。在了解各个字段值的含义之前，请先发起两次调用并观察该字段的变化。\n  "
-    },
     "rich.1cbfc5ef05f8": {
       "type": "rich",
       "source": "<code>\"stop\"</code> means the model has written its final answer and the loop can return <code>content</code> to the user.",
@@ -103,11 +98,6 @@
       "type": "rich",
       "source": "<strong>Memory</strong> is the <code>messages[]</code> array.",
       "value": "<strong>记忆</strong>是 <code>messages[]</code> 数组。"
-    },
-    "rich.32ec8d5bb853": {
-      "type": "rich",
-      "source": "\n    The first call answered on its own and came back <code>\"stop\"</code>. The second was\n    offered a tool and asked for something training data cannot supply, so instead of stopping\n    it came back <code>\"tool_calls\"</code>, handing your code the name of the function to run.\n    Those two values cover the common branching. The rest signal trouble that routes the loop\n    into a fallback harness, where the agent might retry the call or hand the conversation off\n    to a human.\n  ",
-      "value": "\n    第一次调用由模型自行作答，返回了 <code>\"stop\"</code>。第二次调用向模型提供了工具，并要求获取训练数据无法提供的信息，因此它没有停止，而是返回 <code>\"tool_calls\"</code>，将需要运行的函数名称交给代码。这两个值涵盖了常见的分支情况。其余值表示发生了问题，循环会转入后备运行框架；智能体可以在其中重试调用，或将对话转交给人工处理。\n  "
     },
     "rich.37cadcb11b30": {
       "type": "rich",
@@ -139,11 +129,6 @@
       "source": "<code>\"length\"</code> means the token budget ran out before the answer finished.",
       "value": "<code>\"length\"</code> 表示答案尚未生成完毕，token 预算就已耗尽。"
     },
-    "rich.914091fc2532": {
-      "type": "rich",
-      "source": "<strong>Count the steps on a genuinely tool-needing question.</strong>\n        \"How many minutes until 17:00 UTC?\" takes more than one tool call.\n        Run it a few times. Did the model call\n        <code>get_current_time</code> once, twice, or three times? Why\n        would a model re-call a tool whose output it already has,\n        and how would you discourage that in the system prompt?",
-      "value": "<strong>针对一个确实需要工具的问题统计执行步数。</strong>\n        “距离 UTC 17:00 还有多少分钟？”需要进行多次工具调用。多运行几次。模型调用了 <code>get_current_time</code> 一次、两次还是三次？为什么模型会再次调用已经取得输出的工具？您会如何在系统提示词中抑制这种行为？"
-    },
     "rich.9cf78b159479": {
       "type": "rich",
       "source": "\n    The flow is short: the model asks for the tool, the executor appends the timestamp as a\n    <code>tool</code>-role message, the model reads that timestamp, and the loop exits when\n    <code>finish_reason</code> reads <code>\"stop\"</code>.\n  ",
@@ -174,11 +159,6 @@
       "source": "<strong>Action</strong> is the tool call the harness executes.",
       "value": "<strong>行动</strong>是运行框架执行的工具调用。"
     },
-    "rich.d7a22d027748": {
-      "type": "rich",
-      "source": "\n    <strong>What just happened inside the messages array.</strong><br>\n    The loop pushed four things into <code>state.messages</code>: <ul><li>the system\n    prompt (turn 0),</li><li>the user question (turn 1),</li><li>an assistant message with a\n    <code>tool_calls</code> field (turn 2, the request),</li><li>and a\n    <code>tool</code>-role message holding the function's return value (turn\n    3).</li></ul> The second LLM call read all four of those including the new tool result and\n    wrote the final answer. The growing array is the only \"memory\" this\n    agent has. If you saved that array to disk and reloaded it next week, the\n    model would resume the conversation without noticing the gap.\n  ",
-      "value": "\n    <strong>刚才 messages 数组内部发生了什么。</strong><br>\n    循环向 <code>state.messages</code> 中加入了四项：<ul><li>系统提示词（第 0 轮），</li><li>用户的问题（第 1 轮），</li><li>一条带有 <code>tool_calls</code> 字段的 assistant 消息（第 2 轮，即请求），</li><li>以及一条保存函数返回值的 <code>tool</code> 角色消息（第 3 轮）。</li></ul>第二次 LLM 调用读取了这四项，包括新增的工具结果，然后生成最终答案。这个不断增长的数组就是该智能体拥有的全部“记忆”。如果您将该数组保存到磁盘，并在下周重新加载，模型会继续对话，甚至不会察觉中间曾中断过。\n  "
-    },
     "rich.dab40f3dcbce": {
       "type": "rich",
       "source": "\n    Run the cell to build the panel, then chat with it. Pin one or more with\n    the <b>Pages</b> chips to ground every answer in them, or pin nothing and let the\n    agent choose what to read. The reply renders as markdown, with a chip for each source\n    the agent read so you can expand it to see the text it pulled back. Alongside the answer,\n    you also get the reasoning trace and the token usage. It remembers the conversation per chat.\n    Edit the cell and rerun to rebuild the artifact.\n  ",
@@ -188,11 +168,6 @@
       "type": "rich",
       "source": "<strong>Planning</strong> is the <code>finish_reason</code> router.",
       "value": "<strong>规划</strong>是 <code>finish_reason</code> 路由逻辑。"
-    },
-    "text.00b025711499": {
-      "type": "text",
-      "source": "(nothing)",
-      "value": "（无）"
     },
     "text.026e6c091cf3": {
       "type": "text",
@@ -310,11 +285,6 @@
       "source": "The loop is unchanged. With a language model in the reasoning step, the agent reads tool results and acts by calling tools.",
       "value": "循环本身没有变化。以语言模型执行推理步骤时，智能体读取工具结果，并通过调用工具采取行动。"
     },
-    "text.185d5444c22a": {
-      "type": "text",
-      "source": "Compare a direct answer with a tool request. Watch finish_reason change before building the complete loop.",
-      "value": "比较直接回答与工具请求。在构建完整循环之前，观察 finish_reason 如何变化。"
-    },
     "text.1b12f21798d2": {
       "type": "text",
       "source": " Bound the loop so a confused agent cannot spin forever.",
@@ -346,18 +316,6 @@
       "source": "Think, act, observe, repeat. The turn exits the moment finish_reason is \"stop\".",
       "value": "思考、行动、观察、重复。一旦 finish_reason 为 \"stop\"，当前轮次立即结束。"
     },
-    "text.263eb2e3d503": {
-      "type": "text",
-      "source": " \"stop\" means the answer is ready and the loop can exit",
-      "value": " \"stop\" means the answer is ready and the loop can exit",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
-    "text.2744773dba26": {
-      "type": "text",
-      "source": " The model cannot run the tool itself; this preview asks your code to run it.",
-      "value": " The model cannot run the tool itself; this preview asks your code to run it.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
     "text.288ec2e40f38": {
       "type": "text",
       "source": " state.userPrompt   = \"What time is it in UTC?\";",
@@ -385,12 +343,6 @@
       "type": "text",
       "source": "which page, e.g. 01b-react",
       "value": "要读取的页面，例如 01b-react"
-    },
-    "text.2cfc66a4bac0": {
-      "type": "text",
-      "source": " stops or asks for the tool on these same two questions.",
-      "value": " stops or asks for the tool on these same two questions.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.2d08f3745b34": {
       "type": "text",
@@ -433,12 +385,6 @@
       "type": "text",
       "source": "finish_reason:",
       "value": "finish_reason："
-    },
-    "text.36d507134134": {
-      "type": "text",
-      "source": " Optional visibility: uncomment to inspect the complete first response.",
-      "value": " Optional visibility: uncomment to inspect the complete first response.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.3a417d05647e": {
       "type": "text",
@@ -639,12 +585,6 @@
       "value": "✗",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.6a6eb0c995bc": {
-      "type": "text",
-      "source": " \"tool_calls\" means the model is asking you to run a function",
-      "value": " \"tool_calls\" means the model is asking you to run a function",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
     "text.6c45cb72a36e": {
       "type": "text",
       "source": "stop",
@@ -660,12 +600,6 @@
       "type": "text",
       "source": " Pin each selected page in full so the chip reflects the actual context.",
       "value": " Pin each selected page in full so the chip reflects the actual context.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
-    "text.6ec7ac216303": {
-      "type": "text",
-      "source": " Call 1 · no tools offered. The model can answer, so it stops on its own.",
-      "value": " Call 1 · no tools offered. The model can answer, so it stops on its own.",
       "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.761b7ad8ad43": {
@@ -706,12 +640,6 @@
       "type": "text",
       "source": "What time is it right now in UTC?",
       "value": "UTC 现在几点？"
-    },
-    "text.8060fc09ef01": {
-      "type": "text",
-      "source": " MODEL is the swappable brain. Change it and rerun to see whether a stronger model",
-      "value": " MODEL is the swappable brain. Change it and rerun to see whether a stronger model",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.850d8ef32ee1": {
       "type": "text",
@@ -825,17 +753,6 @@
       "value": "🔧",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.aa85ebc76614": {
-      "type": "text",
-      "source": " reasoning models think first; leave room past reasoning_content",
-      "value": " reasoning models think first; leave room past reasoning_content",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
-    "text.aa9c9c97480a": {
-      "type": "text",
-      "source": "(used its whole budget thinking; raise max_tokens)",
-      "value": "（思考耗尽了全部预算；请提高 max_tokens）"
-    },
     "text.ace774147c7e": {
       "type": "text",
       "source": "The complete ReAct loop, built from scratch",
@@ -912,12 +829,6 @@
       "value": "./vendor/langchain-1.4.7.esm.js",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.c3b7187e7262": {
-      "type": "text",
-      "source": " log.details(\"call 1 raw response\", r1);",
-      "value": " log.details(\"call 1 raw response\", r1);",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
     "text.c618570e5e70": {
       "type": "text",
       "source": "🔧 read page · ",
@@ -928,12 +839,6 @@
       "source": "error",
       "value": "error",
       "untranslated": "kept English: exact executable code, protocol, punctuation, or interface literal"
-    },
-    "text.ca32d7f2daac": {
-      "type": "text",
-      "source": " Call 2 · offer one tool and ask for something the model cannot know from training data.",
-      "value": " Call 2 · offer one tool and ask for something the model cannot know from training data.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
     },
     "text.ccc143876d1c": {
       "type": "text",
@@ -990,11 +895,6 @@
       "value": "agent",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.d56573cb0730": {
-      "type": "text",
-      "source": "it asked you to run:",
-      "value": "它要求您运行："
-    },
     "text.d9bda0c06ee1": {
       "type": "text",
       "source": "The same loop, prebuilt and pointed at this course",
@@ -1032,11 +932,6 @@
       "type": "text",
       "source": "course-wide question (\\\\",
       "value": "涉及整个课程的问题（\\\\"
-    },
-    "text.e3ec162f8c8a": {
-      "type": "text",
-      "source": "call 2 · one tool offered, on a question training data cannot answer",
-      "value": "调用 2 · 针对训练数据无法回答的问题提供一个工具"
     },
     "text.e632b7095b0b": {
       "type": "text",
@@ -1112,6 +1007,163 @@
       "source": "tools",
       "value": "tools",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
+    },
+    "rich.04b481fa123f": {
+      "type": "rich",
+      "source": "\n    Every chat-completions response carries a <code>finish_reason</code>\n    field that tells you why the model stopped generating. Inside an agent\n    loop, read it alongside the response content and tool requests to decide what to do next:\n    run a tool, return the answer to the user, or handle an error. Before reading\n    what its values mean, make two calls and compare their replies.\n  ",
+      "value": "每个 Chat Completions 响应都包含 <code>finish_reason</code>，用于说明模型停止生成的原因。在智能体循环中，将它与响应内容和工具请求一起检查，决定执行工具、返回回答还是处理错误。在了解各个值之前，先发出两次调用并比较回复。"
+    },
+    "rich.d503e5a1f6fe": {
+      "type": "rich",
+      "source": "\n    The first call offers no tools. In the second, the model is offered a tool and asked\n    for the current time. It still chooses whether to request the clock tool. Compare the displayed questions, replies, and\n    <code>finish_reason</code>. If both calls return <code>\"stop\"</code>, inspect the\n    second reply: did it admit it cannot check the time, or give an unsupported answer?\n    Change the model or question and rerun. A tool request names work for your code;\n    this preview does not execute it.\n  ",
+      "value": "第一次调用不提供工具。第二次调用向模型提供工具并询问当前时间。是否请求使用时钟工具仍由模型决定。比较显示的问题、回复和 <code>finish_reason</code>。如果两次都返回 <code>\"stop\"</code>，请检查第二条回复：模型承认无法查询时间，还是给出了未经验证的回答？更换模型或问题后重新运行。工具请求只是指明需要代码执行的工作；此预览不会执行工具。"
+    },
+    "rich.71d5f7e1b268": {
+      "type": "rich",
+      "source": "\n    <strong>What just happened inside the messages array.</strong><br>\n    When the model requests the clock, the loop adds these turns to <code>state.messages</code>: <ul><li>the system\n    prompt (turn 0),</li><li>the user question (turn 1),</li><li>an assistant message with a\n    <code>tool_calls</code> field (turn 2, the request),</li><li>and a\n    <code>tool</code>-role message holding the function's return value (turn\n    3).</li></ul> The second LLM call read all four of those including the new tool result and\n    wrote the final answer. The growing array is the only \"memory\" this\n    agent has. If you saved that array to disk and reloaded it next week, the\n    model would resume the conversation without noticing the gap.\n  ",
+      "value": "\n    <strong>刚才 messages 数组内部发生了什么。</strong><br>\n当模型请求时钟时，循环会向 <code>state.messages</code> 中加入以下四项：<ul><li>系统提示词（第 0 轮），</li><li>用户的问题（第 1 轮），</li><li>一条带有 <code>tool_calls</code> 字段的 assistant 消息（第 2 轮，即请求），</li><li>以及一条保存函数返回值的 <code>tool</code> 角色消息（第 3 轮）。</li></ul>第二次 LLM 调用读取了这四项，包括新增的工具结果，然后生成最终答案。这个不断增长的数组就是该智能体拥有的全部“记忆”。如果您将该数组保存到磁盘，并在下周重新加载，模型会继续对话，甚至不会察觉中间曾中断过。\n  "
+    },
+    "rich.925eff5b49ae": {
+      "type": "rich",
+      "source": "<strong>Count the steps on a genuinely tool-needing question.</strong>\n        \"How many minutes until 17:00 UTC?\" needs a clock reading and a calculation.\n        Run it a few times. Did the model call\n        <code>get_current_time</code> once, twice, or three times? Why\n        would a model re-call a tool whose output it already has,\n        and how would you discourage that in the system prompt?",
+      "value": "<strong>统计需要工具的问题所用的步骤。</strong>“距离 17:00 UTC 还有多少分钟？”需要读取时钟并进行计算。运行几次，看看模型调用 <code>get_current_time</code> 一次、两次还是三次。为什么模型会重复调用已获取结果的工具？您会如何修改系统提示词来减少重复调用？"
+    },
+    "text.6998c813031f": {
+      "type": "text",
+      "source": "Compare two questions, the offered tools, and the actual replies. A model may answer or decline without requesting a tool.",
+      "value": "比较两个问题、提供的工具和实际回复。模型可能直接回答或表示无法回答，而不请求工具。"
+    },
+    "text.99e1a8e15403": {
+      "type": "text",
+      "source": " On a custom endpoint, change the model in the connection card; that setting owns the route.",
+      "value": " On a custom endpoint, change the model in the connection card; that setting owns the route.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.408f13277d8d": {
+      "type": "text",
+      "source": "model:",
+      "value": "模型："
+    },
+    "text.1f5087db919c": {
+      "type": "text",
+      "source": "question",
+      "value": "问题"
+    },
+    "text.360cd27d23a6": {
+      "type": "text",
+      "source": "response model:",
+      "value": "响应模型："
+    },
+    "text.5db94652ba22": {
+      "type": "text",
+      "source": "reply:",
+      "value": "回复："
+    },
+    "text.2d27e607c67d": {
+      "type": "text",
+      "source": "(no answer content; inspect the raw response)",
+      "value": "（没有回答内容；请查看原始响应）"
+    },
+    "text.44a36db1abd1": {
+      "type": "text",
+      "source": "call 1 raw response",
+      "value": "调用 1 的原始响应"
+    },
+    "text.6b9eac8f14cf": {
+      "type": "text",
+      "source": " Offering a tool lets the model request it; it does not execute the function.",
+      "value": " Offering a tool lets the model request it; it does not execute the function.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.4809d1df83ab": {
+      "type": "text",
+      "source": " Optional visibility: inspect the exact schema offered to the model.",
+      "value": " Optional visibility: inspect the exact schema offered to the model.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.becc7f440ae3": {
+      "type": "text",
+      "source": " log.json(\"offered tool schema\", TOOLS);",
+      "value": " log.json(\"offered tool schema\", TOOLS);",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
+    },
+    "text.e18b187cecf8": {
+      "type": "text",
+      "source": "call 2 · get_current_time offered",
+      "value": "调用 2 · 提供 get_current_time"
+    },
+    "text.408f13277d8d~1": {
+      "type": "text",
+      "source": "model:",
+      "value": "模型："
+    },
+    "text.1f5087db919c~1": {
+      "type": "text",
+      "source": "question",
+      "value": "问题"
+    },
+    "text.360cd27d23a6~1": {
+      "type": "text",
+      "source": "response model:",
+      "value": "响应模型："
+    },
+    "text.5db94652ba22~1": {
+      "type": "text",
+      "source": "reply:",
+      "value": "回复："
+    },
+    "text.b6d8f3ef94a9": {
+      "type": "text",
+      "source": "(no answer content)",
+      "value": "（没有回答内容）"
+    },
+    "text.dbacd9211eb0": {
+      "type": "text",
+      "source": "requested tools:",
+      "value": "请求的工具："
+    },
+    "text.552e423045fc": {
+      "type": "text",
+      "source": "(none)",
+      "value": "（无）"
+    },
+    "text.90dfb008f2c5": {
+      "type": "text",
+      "source": "call 2 raw response",
+      "value": "调用 2 的原始响应"
+    },
+    "text.e869af251171": {
+      "type": "text",
+      "source": "No clock reading was taken. Inspect the reply, then change the question or model and compare.",
+      "value": "尚未读取时钟。检查回复，然后更换问题或模型并比较结果。"
+    },
+    "text.c9d2fde3d3f2": {
+      "type": "text",
+      "source": " Optional comparison: ask QUESTION_2 to explicitly request the clock tool, then rerun.",
+      "value": " Optional comparison: ask QUESTION_2 to explicitly request the clock tool, then rerun.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.408f13277d8d~2": {
+      "type": "text",
+      "source": "model:",
+      "value": "模型："
+    },
+    "text.1f5087db919c~2": {
+      "type": "text",
+      "source": "question",
+      "value": "问题"
+    },
+    "text.99de16babaa5": {
+      "type": "text",
+      "source": " Optional visibility: inspect the instruction guiding tool use.",
+      "value": " Optional visibility: inspect the instruction guiding tool use.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.9024eab41188": {
+      "type": "text",
+      "source": " helpers.log.kv({ \"system prompt\": state.systemPrompt });",
+      "value": " helpers.log.kv({ \"system prompt\": state.systemPrompt });",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
     }
   }
 }

--- a/i18n/zh/resources/web/nemoclaw/03a-kickstart.html.json
+++ b/i18n/zh/resources/web/nemoclaw/03a-kickstart.html.json
@@ -377,11 +377,6 @@
       "source": "← final chat frame",
       "value": "← 最终聊天帧"
     },
-    "text.17c76e3f9442": {
-      "type": "text",
-      "source": "Run 'Fetch matching models' first.",
-      "value": "请先运行“获取匹配的模型”。"
-    },
     "text.185a2bfff807": {
       "type": "text",
       "source": " Optional visibility: uncomment to inspect the complete timing records.",
@@ -482,18 +477,6 @@
       "type": "text",
       "source": "Return here and enter the launchable URL. If this course is not served by the launchable,\n        paste the launchable's browser access session too.",
       "value": "返回此页面并输入 launchable URL。如果本课程并非由 launchable 提供，还需粘贴 launchable 的浏览器访问会话。"
-    },
-    "text.2b50d1ad6eb6": {
-      "type": "text",
-      "source": " helpers.log.json(\"all model IDs\", data.map(model => model.id));",
-      "value": " helpers.log.json(\"all model IDs\", data.map(model => model.id));",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
-    "text.2bf548d80560": {
-      "type": "text",
-      "source": "glm",
-      "value": "glm",
-      "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
     "text.2c40f2845cfc": {
       "type": "text",
@@ -843,12 +826,6 @@
       "value": "[DONE]",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.70ce88318f4e": {
-      "type": "text",
-      "source": " Optional visibility: uncomment to inspect every model ID before filtering.",
-      "value": " Optional visibility: uncomment to inspect every model ID before filtering.",
-      "untranslated": "runnable code comments remain exactly as authored in the English source"
-    },
     "text.7107f6329249": {
       "type": "text",
       "source": "the loop runs here",
@@ -1013,11 +990,6 @@
       "type": "text",
       "source": "ms · ",
       "value": "毫秒 · "
-    },
-    "text.93497aab615d": {
-      "type": "text",
-      "source": "No models matched filter: ",
-      "value": "没有模型符合筛选条件："
     },
     "text.94aee8a89fe5": {
       "type": "text",
@@ -1301,12 +1273,6 @@
       "value": "models.list",
       "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
-    "text.cd155903dfae": {
-      "type": "text",
-      "source": "120b",
-      "value": "120b",
-      "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
-    },
     "text.cdb4ee2aea69": {
       "type": "text",
       "source": ".",
@@ -1403,12 +1369,6 @@
       "source": "Authenticates the /cli/gateway WebSocket with operator.admin and stores a call() helper so later nodes reuse the connection.",
       "value": "使用 operator.admin 对 /cli/gateway WebSocket 进行身份验证，并存储 call() 辅助函数，供后续节点复用该连接。"
     },
-    "text.e1517be14d06": {
-      "type": "text",
-      "source": "minimax",
-      "value": "minimax",
-      "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
-    },
     "text.e3ee9fe2c8e7": {
       "type": "text",
       "source": " · hit max_tokens",
@@ -1424,12 +1384,6 @@
       "type": "text",
       "source": "code bridge",
       "value": "代码桥接层"
-    },
-    "text.e4f9c522e1c8": {
-      "type": "text",
-      "source": "kimi",
-      "value": "kimi",
-      "untranslated": "kept English: product name, code/protocol literal, canonical citation title, or exact interface label"
     },
     "text.e6e1d0a85eea": {
       "type": "text",
@@ -1551,6 +1505,71 @@
       "type": "text",
       "source": "No API key saved. Go to the course home and save the endpoint and key first.",
       "value": "尚未保存 API key。请先前往课程主页，保存 API 入口和密钥。"
+    },
+    "text.0a07f6594619~2": {
+      "type": "text",
+      "source": ", ",
+      "value": ", ",
+      "untranslated": "Model-list delimiter."
+    },
+    "text.0f9cde8d8684": {
+      "type": "text",
+      "source": "prompt:",
+      "value": "提示："
+    },
+    "text.26bc854fbcb8": {
+      "type": "text",
+      "source": "Connection changed. Rerun Fetch matching models before measuring.",
+      "value": "连接已更改。请先重新运行模型发现步骤，再测量延迟。"
+    },
+    "text.29367fb9bc12": {
+      "type": "text",
+      "source": " Start with the configured model; edit using the catalog IDs below.",
+      "value": " Start with the configured model; edit using the catalog IDs below.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.7449100a979f": {
+      "type": "text",
+      "source": "No models matched. Choose an ID from available model IDs, edit FILTER, and rerun discovery.",
+      "value": "没有匹配的模型。请从可用模型 ID 中选择一个，修改 FILTER，然后重新运行发现步骤。"
+    },
+    "text.7ba81713b6a9": {
+      "type": "text",
+      "source": " A failed discovery must not reuse models from an earlier run.",
+      "value": " A failed discovery must not reuse models from an earlier run.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.82d65f6c7bcc": {
+      "type": "text",
+      "source": "available model IDs",
+      "value": "可用模型 ID"
+    },
+    "text.8967a0229e67": {
+      "type": "text",
+      "source": "filter:",
+      "value": "筛选条件："
+    },
+    "text.d08f12eafde7": {
+      "type": "text",
+      "source": "Fetch matching models must return at least one model. Inspect its catalog and filter, then rerun it.",
+      "value": "模型发现步骤必须返回至少一个模型。请检查目录和筛选条件，然后重新运行。"
+    },
+    "text.e01ccf75a80a": {
+      "type": "text",
+      "source": "models:",
+      "value": "模型："
+    },
+    "text.ba3981b425bd": {
+      "type": "text",
+      "source": " Optional visibility: inspect the complete catalog entries.",
+      "value": " Optional visibility: inspect the complete catalog entries.",
+      "untranslated": "Canonical executable comment retained in English under the Chinese locale contract."
+    },
+    "text.d72346306aa8": {
+      "type": "text",
+      "source": " helpers.log.json(\"catalog response\", { data });",
+      "value": " helpers.log.json(\"catalog response\", { data });",
+      "untranslated": "Editable JavaScript diagnostic statement with preserved identifiers."
     }
   }
 }

--- a/tests/validation/SKILL.html
+++ b/tests/validation/SKILL.html
@@ -106,6 +106,11 @@
       "desc": "Python source in tests/validation/."
     },
     {
+      "path": "test_course_observability.py",
+      "role": "Python source",
+      "desc": "Python source in tests/validation/."
+    },
+    {
       "path": "test_embedded_validator_suites.py",
       "role": "Python source",
       "desc": "Python source in tests/validation/."
@@ -273,6 +278,7 @@
       <li><a href="test_cors_proxy_projection_audit.py"><code>test_cors_proxy_projection_audit.py</code></a></li>
       <li><a href="test_course_content_contract.py"><code>test_course_content_contract.py</code></a></li>
       <li><a href="test_course_contract.py"><code>test_course_contract.py</code></a></li>
+      <li><a href="test_course_observability.py"><code>test_course_observability.py</code></a></li>
       <li><a href="test_embedded_validator_suites.py"><code>test_embedded_validator_suites.py</code></a></li>
       <li><a href="test_figure_provenance_theme.py"><code>test_figure_provenance_theme.py</code></a></li>
       <li><a href="test_foyer_branch_paths.py"><code>test_foyer_branch_paths.py</code></a></li>

--- a/tests/validation/test_course_observability.py
+++ b/tests/validation/test_course_observability.py
@@ -13,10 +13,19 @@ const fs = require('node:fs');
 const vm = require('node:vm');
 const path = require('node:path');
 const root = process.cwd();
-function cell(page, id) {
-  const source = fs.readFileSync(path.join(root, 'web/nemoclaw', page), 'utf8');
-  const start = source.indexOf('mountRunCell("#' + id + '"');
-  assert(start >= 0, id);
+function cell(id, directory = path.join(root, 'web')) {
+  const marker = 'mountRunCell("#' + id + '"';
+  function sources(dir) {
+    return fs.readdirSync(dir, {withFileTypes: true}).flatMap(entry => {
+      const file = path.join(dir, entry.name);
+      if (entry.isDirectory()) return sources(file);
+      return entry.isFile() && entry.name.endsWith('.html') ? [fs.readFileSync(file, 'utf8')] : [];
+    });
+  }
+  const matches = sources(directory).filter(source => source.includes(marker));
+  assert.equal(matches.length, 1, id + ': expected one authored cell');
+  const source = matches[0];
+  const start = source.indexOf(marker);
   const rest = source.slice(start);
   const match = rest.match(/code:\s*(`(?:\\[\s\S]|[^`\\])*`)/);
   assert(match, id + ' code');
@@ -42,8 +51,23 @@ const helpers = {
   },
 };
 (async () => {
-  const discovery = cell('03a-kickstart.html', 'bench-fetch-models');
-  const measure = cell('03a-kickstart.html', 'bench-measure-models');
+  const temporary = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'cell-discovery-'));
+  try {
+    const nested = path.join(temporary, 'new-course', 'lessons');
+    fs.mkdirSync(nested, {recursive: true});
+    const original = path.join(nested, 'new-lesson.html');
+    const renamed = path.join(nested, 'renamed-lesson.html');
+    fs.writeFileSync(original, 'mountRunCell("#probe", {code: `return 7;`});');
+    assert.equal(cell('probe', temporary), 'return 7;');
+    fs.renameSync(original, renamed);
+    assert.equal(cell('probe', temporary), 'return 7;');
+    fs.writeFileSync(renamed, 'mountRunCell("#probe-near-match", {code: `return 7;`});');
+    assert.throws(() => cell('probe', temporary), /expected one authored cell/);
+    fs.unlinkSync(renamed);
+    assert.throws(() => cell('probe', temporary), /expected one authored cell/);
+  } finally { fs.rmSync(temporary, {recursive: true, force: true}); }
+  const discovery = cell('bench-fetch-models');
+  const measure = cell('bench-measure-models');
   const state = {};
   await run(discovery, state, helpers);
   assert.deepEqual(state.models, ['course/agent']);
@@ -73,7 +97,7 @@ const helpers = {
   await run(discovery, state, helpers);
   assert.deepEqual(state.models, []);
   config.needsKey = false;
-  const preview = cell('01b-react.html', 'cell-finish-reason');
+  const preview = cell('cell-finish-reason');
   for (const toolCalls of [[], [{id: 'call-clock', function: {name: 'get_current_time', arguments: '{}'}}]]) {
     config.model = toolCalls.length ? 'provider/switched-model' : 'course/agent';
     const sent = [];

--- a/tests/validation/test_course_observability.py
+++ b/tests/validation/test_course_observability.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Execute the authored cells against bounded transport fixtures."""
+from pathlib import Path
+import subprocess
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+SCRIPT = r'''
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+const root = process.cwd();
+function cell(page, id) {
+  const source = fs.readFileSync(path.join(root, 'web/nemoclaw', page), 'utf8');
+  const start = source.indexOf('mountRunCell("#' + id + '"');
+  assert(start >= 0, id);
+  const rest = source.slice(start);
+  const match = rest.match(/code:\s*(`(?:\\[\s\S]|[^`\\])*`)/);
+  assert(match, id + ' code');
+  return vm.runInNewContext(match[1]);
+}
+const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+const run = (code, state, helpers) => new AsyncFunction('state', 'helpers', 'log', 'chat', code)(state, helpers, helpers.log, helpers.chat);
+const logs = [];
+const log = (...args) => logs.push(args.join(' '));
+log.h = log; log.details = log; log.json = log;
+log.kv = object => Object.entries(object).forEach(([key, value]) => log(key, value));
+const config = {url: 'https://course.test/api/llm/v1', model: 'course/agent', needsKey: false};
+let key = '', catalog = [{id: 'course/agent'}, {id: 'provider/chat'}, {id: 'provider/vision'}];
+let status = 200;
+const requests = [];
+const helpers = {
+  log, signal: new AbortController().signal,
+  getConfig: async () => config, getKey: () => key,
+  isDefaultModelApiBaseUrl: () => false,
+  browserChatFetch: () => async (url, init) => {
+    requests.push({url, init});
+    return new Response(JSON.stringify({data: catalog}), {status});
+  },
+};
+(async () => {
+  const discovery = cell('03a-kickstart.html', 'bench-fetch-models');
+  const measure = cell('03a-kickstart.html', 'bench-measure-models');
+  const state = {};
+  await run(discovery, state, helpers);
+  assert.deepEqual(state.models, ['course/agent']);
+  assert.equal(requests[0].init.headers.Authorization, undefined);
+  assert.equal(requests[0].init.signal, helpers.signal);
+  assert(logs.some(line => line.includes('available model IDs')));
+  catalog = [{id: 'provider/novel-chat'}];
+  await run(discovery, state, helpers);
+  assert.deepEqual(state.models, []);
+  assert(logs.some(line => line.includes('edit FILTER')));
+  const before = requests.length;
+  await run(measure, state, helpers);
+  assert.equal(requests.length, before);
+  catalog = [{id: 'course/agent'}];
+  await run(discovery, state, helpers);
+  status = 503;
+  await run(discovery, state, helpers);
+  assert.deepEqual(state.models, []);
+  status = 200;
+  await run(discovery, state, helpers);
+  config.url = 'https://changed.test/v1';
+  const beforeChange = requests.length;
+  await run(measure, state, helpers);
+  assert.equal(requests.length, beforeChange);
+  assert(logs.some(line => line.includes('Connection changed')));
+  config.needsKey = true;
+  await run(discovery, state, helpers);
+  assert.deepEqual(state.models, []);
+  config.needsKey = false;
+  const preview = cell('01b-react.html', 'cell-finish-reason');
+  for (const toolCalls of [[], [{id: 'call-clock', function: {name: 'get_current_time', arguments: '{}'}}]]) {
+    config.model = toolCalls.length ? 'provider/switched-model' : 'course/agent';
+    const sent = [];
+    helpers.chat = async body => {
+      sent.push(body);
+      return {model: 'provider/actual-model', choices: [{finish_reason: body.tools && toolCalls.length ? 'tool_calls' : 'stop', message: {content: 'I cannot check the time here.', tool_calls: body.tools ? toolCalls : []}}]};
+    };
+    logs.length = 0;
+    const result = await run(preview, {}, helpers);
+    assert.equal(sent.length, 2);
+    assert(sent.every(body => body.model === config.model));
+    for (const body of sent) assert(logs.some(line => line.includes(body.messages[0].content)));
+    assert(logs.some(line => line.includes('I cannot check the time here.')));
+    assert(logs.some(line => line.includes('provider/actual-model')));
+    assert.equal(result.call2, toolCalls.length ? 'tool_calls' : 'stop');
+    assert.equal(logs.some(line => line.includes('No clock reading was taken')), !toolCalls.length);
+  }
+  console.log('PASS: authored preview, model identity, keyless catalog, no-match recovery, failed discovery, stale connection, missing key');
+})().catch(error => { console.error(error); process.exitCode = 1; });
+'''
+
+
+class CourseObservabilityTests(unittest.TestCase):
+    def test_authored_cells_preserve_inputs_and_failure_state(self):
+        result = subprocess.run(
+            ["node", "-e", SCRIPT], cwd=ROOT, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/nemoclaw/01b-react.html
+++ b/web/nemoclaw/01b-react.html
@@ -68,20 +68,20 @@
   <p>
     Every chat-completions response carries a <code>finish_reason</code>
     field that tells you why the model stopped generating. Inside an agent
-    loop, this is the only signal you need to decide what to do next:
+    loop, read it alongside the response content and tool requests to decide what to do next:
     run a tool, return the answer to the user, or handle an error. Before reading
-    what its values mean, make two calls and watch the field change.
+    what its values mean, make two calls and compare their replies.
   </p>
 
   <div id="cell-finish-reason"></div>
 
   <p>
-    The first call answered on its own and came back <code>"stop"</code>. The second was
-    offered a tool and asked for something training data cannot supply, so instead of stopping
-    it came back <code>"tool_calls"</code>, handing your code the name of the function to run.
-    Those two values cover the common branching. The rest signal trouble that routes the loop
-    into a fallback harness, where the agent might retry the call or hand the conversation off
-    to a human.
+    The first call offers no tools. In the second, the model is offered a tool and asked
+    for the current time. It still chooses whether to request the clock tool. Compare the displayed questions, replies, and
+    <code>finish_reason</code>. If both calls return <code>"stop"</code>, inspect the
+    second reply: did it admit it cannot check the time, or give an unsupported answer?
+    Change the model or question and rerun. A tool request names work for your code;
+    this preview does not execute it.
   </p>
   <ul>
     <li><code>"stop"</code> means the model has written its final answer and the loop can return <code>content</code> to the user.</li>
@@ -173,7 +173,7 @@
 
   <div class="callout">
     <strong>What just happened inside the messages array.</strong><br>
-    The loop pushed four things into <code>state.messages</code>: <ul><li>the system
+    When the model requests the clock, the loop adds these turns to <code>state.messages</code>: <ul><li>the system
     prompt (turn 0),</li><li>the user question (turn 1),</li><li>an assistant message with a
     <code>tool_calls</code> field (turn 2, the request),</li><li>and a
     <code>tool</code>-role message holding the function's return value (turn
@@ -256,7 +256,7 @@
         steers a model that has training-data confidence in another
         direction?</li>
     <li><strong>Count the steps on a genuinely tool-needing question.</strong>
-        "How many minutes until 17:00 UTC?" takes more than one tool call.
+        "How many minutes until 17:00 UTC?" needs a clock reading and a calculation.
         Run it a few times. Did the model call
         <code>get_current_time</code> once, twice, or three times? Why
         would a model re-call a tool whose output it already has,
@@ -296,25 +296,28 @@ hljs.highlightAll();
 mountRunCell("#cell-finish-reason", {
   openCode: true,
   label: "finish_reason · the one field the loop reads to decide what to do next",
-  intro: "Compare a direct answer with a tool request. Watch finish_reason change before building the complete loop.",
-  code: `// MODEL is the swappable brain. Change it and rerun to see whether a stronger model
-// stops or asks for the tool on these same two questions.
-const MODEL = "nvidia/nemotron-3.5-lightning-30b-a3b";
+  intro: "Compare two questions, the offered tools, and the actual replies. A model may answer or decline without requesting a tool.",
+  code: `// On a custom endpoint, change the model in the connection card; that setting owns the route.
+const CFG = await helpers.getConfig();
+const MODEL = helpers.isDefaultModelApiBaseUrl(CFG.url)
+  ? "nvidia/nemotron-3.5-lightning-30b-a3b" : CFG.model;
+const QUESTION_1 = "In one sentence, what is an agent's ReAct loop?";
+const QUESTION_2 = "What time is it right now in UTC?";
 
-// Call 1 · no tools offered. The model can answer, so it stops on its own.
+log.h("call 1 · no tools offered");
+log("model:", MODEL);
+log.kv({ "question": QUESTION_1 });
 const r1 = await chat({
   model: MODEL,
-  messages: [{ role: "user", content: "In one sentence, what is an agent's ReAct loop?" }],
-  max_tokens: 8196,  // reasoning models think first; leave room past reasoning_content
+  messages: [{ role: "user", content: QUESTION_1 }],
+  max_tokens: 8196,
 });
-// Optional visibility: uncomment to inspect the complete first response.
-// log.details("call 1 raw response", r1);
-log.h("call 1 · no tools offered");
-log("finish_reason:", r1.choices[0].finish_reason);   // "stop" means the answer is ready and the loop can exit
-log(r1.choices[0].message.content || "(used its whole budget thinking; raise max_tokens)");
+log("response model:", r1.model || MODEL);
+log("finish_reason:", r1.choices[0].finish_reason);
+log("reply:", r1.choices[0].message.content || "(no answer content; inspect the raw response)");
+log.details("call 1 raw response", r1);
 
-// Call 2 · offer one tool and ask for something the model cannot know from training data.
-// The model cannot run the tool itself; this preview asks your code to run it.
+// Offering a tool lets the model request it; it does not execute the function.
 const TOOLS = [{
   type: "function",
   function: {
@@ -323,18 +326,28 @@ const TOOLS = [{
     parameters: { type: "object", properties: {}, required: [] },
   },
 }];
+// Optional visibility: inspect the exact schema offered to the model.
+// log.json("offered tool schema", TOOLS);
+log.h("call 2 · get_current_time offered");
+log("model:", MODEL);
+log.kv({ "question": QUESTION_2 });
 const r2 = await chat({
   model: MODEL,
-  messages: [{ role: "user", content: "What time is it right now in UTC?" }],
+  messages: [{ role: "user", content: QUESTION_2 }],
   tools: TOOLS,
   max_tokens: 8196,
 });
 const m2 = r2.choices[0].message;
-log.h("call 2 · one tool offered, on a question training data cannot answer");
-log("finish_reason:", r2.choices[0].finish_reason);   // "tool_calls" means the model is asking you to run a function
-log("it asked you to run:", (m2.tool_calls || []).map(t => t.function.name).join(", ") || "(nothing)");
-
-return { call1: r1.choices[0].finish_reason, call2: r2.choices[0].finish_reason };
+log("response model:", r2.model || MODEL);
+log("finish_reason:", r2.choices[0].finish_reason);
+log("reply:", m2.content || "(no answer content)");
+log("requested tools:", (m2.tool_calls || []).map(t => t.function.name).join(", ") || "(none)");
+log.details("call 2 raw response", r2);
+if (!m2.tool_calls?.length) {
+  log("No clock reading was taken. Inspect the reply, then change the question or model and compare.");
+}
+// Optional comparison: ask QUESTION_2 to explicitly request the clock tool, then rerun.
+return { model: MODEL, call1: r1.choices[0].finish_reason, call2: r2.choices[0].finish_reason };
 `,
 });
 
@@ -384,7 +397,13 @@ return state.execTool("get_current_time");
       summary: "Runs the ReAct cycle until finish_reason is 'stop'. Edit MODEL to compare another model.",
       code: `// MODEL is the swappable brain in the reasoning slot. Change it and rerun to drive the
 // same loop with a different model.
-const MODEL = "nvidia/nemotron-3.5-lightning-30b-a3b";
+const CFG = await helpers.getConfig();
+const MODEL = helpers.isDefaultModelApiBaseUrl(CFG.url)
+  ? "nvidia/nemotron-3.5-lightning-30b-a3b" : CFG.model;
+helpers.log("model:", MODEL);
+helpers.log.kv({ "question": state.userPrompt });
+// Optional visibility: inspect the instruction guiding tool use.
+// helpers.log.kv({ "system prompt": state.systemPrompt });
 // Backstop for runaway tool loops during the demo.
 const max_steps = 12;
 

--- a/web/nemoclaw/03a-kickstart.html
+++ b/web/nemoclaw/03a-kickstart.html
@@ -520,6 +520,7 @@ if (!models.length) {
 helpers.log(models.length + " model(s) to bench:\\n  " + models.join("\\n  "));
 state.models = models;
 state.endpoint = ENDPOINT;
+state.configUrl = CFG.url;
 state.key    = KEY;
 return { count: models.length };`,
     });
@@ -529,7 +530,7 @@ return { count: models.length };`,
       code: `// Stream one prompt through each selected model and measure first-token latency.
 if (!state.models?.length) { helpers.log("Fetch matching models must return at least one model. Inspect its catalog and filter, then rerun it."); return; }
 const CFG = await helpers.getConfig();
-if (state.endpoint !== CFG.url.replace(/\\/+$/, "") || state.key !== (helpers.getKey() || "")) {
+if (state.configUrl !== CFG.url || state.key !== (helpers.getKey() || "")) {
   helpers.log("Connection changed. Rerun Fetch matching models before measuring.");
   return;
 }

--- a/web/nemoclaw/03a-kickstart.html
+++ b/web/nemoclaw/03a-kickstart.html
@@ -461,8 +461,7 @@ NVIDIA API keys start with <code>nvapi-</code>.</p>
       },
       actions: [
         {
-          label: "GET /v1/models", path: "/models", method: "GET",
-          filterModels: ["120b", "glm", "kimi", "minimax"]
+          label: "GET /v1/models", path: "/models", method: "GET"
         },
 
         {
@@ -491,26 +490,31 @@ NVIDIA API keys start with <code>nvapi-</code>.</p>
       openCode: true,
       intro: "Run this short discovery request first. It lists models matching the editable prefix; code stays visible because changing that filter is the exercise.",
       code: `// Fetch the model catalog and keep only the IDs this benchmark compares.
-const FILTER = ["120b", "glm", "kimi", "minimax"];
-const CFG      = await helpers.getConfig();
+state.models = []; // A failed discovery must not reuse models from an earlier run.
+state.results = [];
+const CFG = await helpers.getConfig();
+const FILTER = [CFG.model]; // Start with the configured model; edit using the catalog IDs below.
 const ENDPOINT = CFG.url.replace(/\\/+$/, "");
 const KEY    = helpers.getKey() || "";
 
-if (!KEY) {
+if (CFG.needsKey && !KEY) {
   helpers.log("No API key saved. Go to the course home and save the endpoint and key first.");
   return;
 }
 const r = await helpers.browserChatFetch()(ENDPOINT + "/models", {
-  headers: { Authorization: "Bearer " + KEY },
+  headers: KEY ? { Authorization: "Bearer " + KEY } : {},
+  signal: helpers.signal,
 });
 
 if (!r.ok) { helpers.log("models fetch failed: HTTP " + r.status); return; }
 const { data } = await r.json();
-// Optional visibility: uncomment to inspect every model ID before filtering.
-// helpers.log.json("all model IDs", data.map(model => model.id));
+// Optional visibility: inspect the complete catalog entries.
+// helpers.log.json("catalog response", { data });
+helpers.log.details("available model IDs", data.map(model => model.id));
+helpers.log("filter:", FILTER.join(", "));
 const models = data.map(m => m.id).filter(id => FILTER.some(s => id.toLowerCase().includes(s.toLowerCase())));
 if (!models.length) {
-  helpers.log("No models matched filter: " + FILTER.join(", "));
+  helpers.log("No models matched. Choose an ID from available model IDs, edit FILTER, and rerun discovery.");
   return;
 }
 helpers.log(models.length + " model(s) to bench:\\n  " + models.join("\\n  "));
@@ -523,11 +527,18 @@ return { count: models.length };`,
     mountRunCell("#bench-measure-models", {
       label: "Measure TTFT per model",
       code: `// Stream one prompt through each selected model and measure first-token latency.
-if (!state.models?.length) { helpers.log("Run 'Fetch matching models' first."); return; }
+if (!state.models?.length) { helpers.log("Fetch matching models must return at least one model. Inspect its catalog and filter, then rerun it."); return; }
+const CFG = await helpers.getConfig();
+if (state.endpoint !== CFG.url.replace(/\\/+$/, "") || state.key !== (helpers.getKey() || "")) {
+  helpers.log("Connection changed. Rerun Fetch matching models before measuring.");
+  return;
+}
 const PROMPT       = "List five prime numbers.";
 // Try another prompt (uncomment one) to compare how the models behave on different work:
 // const PROMPT    = "Explain step by step why the sky is blue.";                // a reasoning task
 // const PROMPT    = "Write a haiku about GPUs, then one line on what it means."; // a longer generation
+helpers.log("prompt:", PROMPT);
+helpers.log("models:", state.models.join(", "));
 const MAX_TOKENS   = 256;     // reasoning models think first; too low and they never answer
 const TTFT_TIMEOUT = 30000;   // ms; give up on a model with no first token by now (some are slow to start)
 
@@ -545,7 +556,7 @@ async function bench(model) {
   try {
     const r = await helpers.browserChatFetch()(state.endpoint + "/chat/completions", {
       method: "POST",
-      headers: { Authorization: "Bearer " + state.key, "Content-Type": "application/json" },
+      headers: { ...(state.key ? { Authorization: "Bearer " + state.key } : {}), "Content-Type": "application/json" },
       body: JSON.stringify({ model, messages: [{ role: "user", content: PROMPT }], max_tokens: MAX_TOKENS, stream: true }),
       signal: ctrl.signal,
     });

--- a/web/nemoclaw/assets/localization-es.json
+++ b/web/nemoclaw/assets/localization-es.json
@@ -118,10 +118,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "reviewed_source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "target_sha256": "8bac4ae27fafcefd6f1d1227321dbfe636fc9fa45043066a677e5165b777cef0",
-      "reviewed_target_sha256": "8bac4ae27fafcefd6f1d1227321dbfe636fc9fa45043066a677e5165b777cef0",
+      "source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "reviewed_source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "target_sha256": "20507fd0ca896a0806713c2527924b47152574e67d04d09f24626d5a72b5ed18",
+      "reviewed_target_sha256": "20507fd0ca896a0806713c2527924b47152574e67d04d09f24626d5a72b5ed18",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-es.json
+++ b/web/nemoclaw/assets/localization-es.json
@@ -63,10 +63,10 @@
     {
       "path": "web/nemoclaw/01b-react.html",
       "file": "01b-react.html",
-      "source_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "reviewed_source_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "target_sha256": "ab6440779484d354cd50fc50af70271551477b63b300f6741cb7624e4db8bb84",
-      "reviewed_target_sha256": "ab6440779484d354cd50fc50af70271551477b63b300f6741cb7624e4db8bb84",
+      "source_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "reviewed_source_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "target_sha256": "7a39d4f661667a48d5a4e76d1e2a8864a25988a448216808783749ed72d73952",
+      "reviewed_target_sha256": "7a39d4f661667a48d5a4e76d1e2a8864a25988a448216808783749ed72d73952",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []
@@ -118,10 +118,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "reviewed_source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "target_sha256": "c68dadc8bfdf20e51838ffa5adf3379e7a3fc07c2817e2f45d7c6af421ceec32",
-      "reviewed_target_sha256": "c68dadc8bfdf20e51838ffa5adf3379e7a3fc07c2817e2f45d7c6af421ceec32",
+      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "reviewed_source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "target_sha256": "8bac4ae27fafcefd6f1d1227321dbfe636fc9fa45043066a677e5165b777cef0",
+      "reviewed_target_sha256": "8bac4ae27fafcefd6f1d1227321dbfe636fc9fa45043066a677e5165b777cef0",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-pt.json
+++ b/web/nemoclaw/assets/localization-pt.json
@@ -63,10 +63,10 @@
     {
       "path": "web/nemoclaw/01b-react.html",
       "file": "01b-react.html",
-      "source_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "reviewed_source_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "target_sha256": "be078c7554fc273875e7de58c6191efcaae9b454df7e40fb2c6d7815d08dc7fc",
-      "reviewed_target_sha256": "be078c7554fc273875e7de58c6191efcaae9b454df7e40fb2c6d7815d08dc7fc",
+      "source_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "reviewed_source_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "target_sha256": "2b83a9c44bd5241a015fad5c4ec3fa274c4e560dfed890a3c9c7e00aaafe2848",
+      "reviewed_target_sha256": "2b83a9c44bd5241a015fad5c4ec3fa274c4e560dfed890a3c9c7e00aaafe2848",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []
@@ -118,10 +118,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "reviewed_source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "target_sha256": "364056350c3d84854125907212e4a9cf9883335d5738115b2ec4e4d7eceb5e21",
-      "reviewed_target_sha256": "364056350c3d84854125907212e4a9cf9883335d5738115b2ec4e4d7eceb5e21",
+      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "reviewed_source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "target_sha256": "e6c17106fe093770ec584baddd8189a98635f04dfdbd55b94049ac472ef2e14e",
+      "reviewed_target_sha256": "e6c17106fe093770ec584baddd8189a98635f04dfdbd55b94049ac472ef2e14e",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-pt.json
+++ b/web/nemoclaw/assets/localization-pt.json
@@ -118,10 +118,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "reviewed_source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "target_sha256": "e6c17106fe093770ec584baddd8189a98635f04dfdbd55b94049ac472ef2e14e",
-      "reviewed_target_sha256": "e6c17106fe093770ec584baddd8189a98635f04dfdbd55b94049ac472ef2e14e",
+      "source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "reviewed_source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "target_sha256": "b4a0280b17b01920b66363ee762d44450ca1f003673200641bea5d0ecca719d8",
+      "reviewed_target_sha256": "b4a0280b17b01920b66363ee762d44450ca1f003673200641bea5d0ecca719d8",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-tw.json
+++ b/web/nemoclaw/assets/localization-tw.json
@@ -67,10 +67,10 @@
     {
       "path": "web/nemoclaw/01b-react.html",
       "file": "01b-react.html",
-      "source_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "reviewed_source_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "target_sha256": "b53e9c57d6697c51394255ed096e2054a83e3ea84e59074a862ef69135608503",
-      "reviewed_target_sha256": "b53e9c57d6697c51394255ed096e2054a83e3ea84e59074a862ef69135608503",
+      "source_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "reviewed_source_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "target_sha256": "c536d75868fee552b7450ff7806674f82e5c05a66c6456182ae00234f62f2157",
+      "reviewed_target_sha256": "c536d75868fee552b7450ff7806674f82e5c05a66c6456182ae00234f62f2157",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []
@@ -122,10 +122,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "reviewed_source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "target_sha256": "e7a1febe24970eee08af23b60c601af957823890c740d2689f4443a444e06235",
-      "reviewed_target_sha256": "e7a1febe24970eee08af23b60c601af957823890c740d2689f4443a444e06235",
+      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "reviewed_source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "target_sha256": "1b727bf6ef7676ddf53f293fff8ef2f2428f314df07130ac46aaf67248c4856c",
+      "reviewed_target_sha256": "1b727bf6ef7676ddf53f293fff8ef2f2428f314df07130ac46aaf67248c4856c",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-tw.json
+++ b/web/nemoclaw/assets/localization-tw.json
@@ -122,10 +122,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "reviewed_source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "target_sha256": "1b727bf6ef7676ddf53f293fff8ef2f2428f314df07130ac46aaf67248c4856c",
-      "reviewed_target_sha256": "1b727bf6ef7676ddf53f293fff8ef2f2428f314df07130ac46aaf67248c4856c",
+      "source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "reviewed_source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "target_sha256": "169c4ea46a8e713512a6d73733d16522183028af378e2de0d9e1b5c357360138",
+      "reviewed_target_sha256": "169c4ea46a8e713512a6d73733d16522183028af378e2de0d9e1b5c357360138",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-zh.json
+++ b/web/nemoclaw/assets/localization-zh.json
@@ -122,10 +122,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "reviewed_source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
-      "target_sha256": "c7d2d7109ecd8994764694d52e3596be3a2f3083a24f1d5be29888c765095ef0",
-      "reviewed_target_sha256": "c7d2d7109ecd8994764694d52e3596be3a2f3083a24f1d5be29888c765095ef0",
+      "source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "reviewed_source_sha256": "26912b9ea0fd009541adcdcf11828e0de1bf5cc91aa5591969501a80d55fb29a",
+      "target_sha256": "22fae2a0791a379e26e3f1f214d71783a819060ab5cf64aee6b47f829f2b5d21",
+      "reviewed_target_sha256": "22fae2a0791a379e26e3f1f214d71783a819060ab5cf64aee6b47f829f2b5d21",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/assets/localization-zh.json
+++ b/web/nemoclaw/assets/localization-zh.json
@@ -67,10 +67,10 @@
     {
       "path": "web/nemoclaw/01b-react.html",
       "file": "01b-react.html",
-      "source_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "reviewed_source_sha256": "778427120d4e33596d2c9c4ae6903b338aee6a3114b8d7eb457f4cb08c1bce07",
-      "target_sha256": "ed031333d20242cd89871e72aa6fe006bcdd30e1da52fce2b1b52248185639f7",
-      "reviewed_target_sha256": "ed031333d20242cd89871e72aa6fe006bcdd30e1da52fce2b1b52248185639f7",
+      "source_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "reviewed_source_sha256": "82f645a7373d69a0e129ec6e584e56a7c403e37418a6798e8c9cf90e329d4207",
+      "target_sha256": "0b7f1faee9d0e75dcb24543eb3346bfa914d1d42a0513323b93c1c0ad36ef981",
+      "reviewed_target_sha256": "0b7f1faee9d0e75dcb24543eb3346bfa914d1d42a0513323b93c1c0ad36ef981",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []
@@ -122,10 +122,10 @@
     {
       "path": "web/nemoclaw/03a-kickstart.html",
       "file": "03a-kickstart.html",
-      "source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "reviewed_source_sha256": "1518b4814691bd06a3a73b46dfafe92b45729f3008a5a484efce79e88507b75b",
-      "target_sha256": "bab48c3bfde9b87a7b5cb281c092eef144b4ecd8f85aef27001b31fdd7b2ce68",
-      "reviewed_target_sha256": "bab48c3bfde9b87a7b5cb281c092eef144b4ecd8f85aef27001b31fdd7b2ce68",
+      "source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "reviewed_source_sha256": "23882c5113544367cc94552f36a0777464c743468c375e3ab08308d8b0c598aa",
+      "target_sha256": "c7d2d7109ecd8994764694d52e3596be3a2f3083a24f1d5be29888c765095ef0",
+      "reviewed_target_sha256": "c7d2d7109ecd8994764694d52e3596be3a2f3083a24f1d5be29888c765095ef0",
       "target_representation": "locale-resource",
       "status": "current",
       "quality": []

--- a/web/nemoclaw/vendor/browser-dependencies.json
+++ b/web/nemoclaw/vendor/browser-dependencies.json
@@ -1243,7 +1243,7 @@
       "references": [
         {
           "source": "web/nemoclaw/01b-react.html",
-          "line": 441
+          "line": 460
         },
         {
           "source": "web/nemoclaw/02c-deep.html",


### PR DESCRIPTION
## Summary

Show both ReAct questions, replies, requested/reported models and tool decisions. Make benchmark discovery use the configured model and recover from empty catalogs, failed requests and changed connections.

## Issue link

Addresses #127

## Surfaces touched

- [x] `web/`
- [x] `i18n/`
- [ ] `scripts/`
- [ ] CI and repository automation
- [ ] `docs/`
- [ ] `materials/source governance`

Uses the existing key/value logger for visible questions and adds authored-cell regression coverage.

## Blast radius checked

Both lessons, the existing chat/configuration helpers, four locale projections and browser dependency references. The tool decision remains the model's; the preview never executes the offered clock function. Custom routes retain their configured model.

## Validation evidence

PASS: authored-cell regression, cell audit, eight locale resource/acceptance checks, and Chromium execution of all eight localized pages. Fixture coverage includes model switching, stop/tool requests, keyless discovery, missing keys, empty/failed discovery and stale connections.

PASS on `13619426791778b2a9410317422a0b35f5458710`: all 94 release checks, including 520 regression tests and 54 locale-resource tests; public and preview Pages builds, artifact integrity, preview smoke and browser-runtime checks. Signed-history contribution, sensitive-content, path-leak and specialization checks passed. Hosted results are recorded in the [PR Checks tab](https://github.com/NVDLI/NemoClawDLI/pull/128/checks).

## Human ownership

The maintainer explicitly assigned the changed es-ES, pt-BR, zh-CN and zh-TW text to Codex for review. Codex read the prose/locale rules and reviewed the changed source and rendered text; this is not an independent human review. Changelog records that ownership. Maintainer merge and release review remains pending.

## Risk and rollback

Model selection and stale discovery state are the affected behavior. Revert the PR merge to restore the previous lessons and locale projections.

## Out of scope

Gateway redesign, provider/model changes, forced tool calls, telemetry, CI policy and production deployment.

## Current release target

The public browser course under `web/nemoclaw/`, with its existing configured model routes. Scope: two lessons, four locales and focused regression coverage.

## Security and source impact

No dependencies, permissions, external material, licenses or release authority change. The generated dependency inventory only updates a source line number. Existing fetch ownership is preserved; keyless requests omit an empty bearer header.

## External release follow-up

Threat/architecture and new-material license review: NOT APPLICABLE. Final candidate secret/vulnerability checks and artifact release evidence: REQUIRED before publication.

## Release notes

Keep model inputs and decisions visible with code collapsed. Show available catalog IDs and explain how to recover discovery before measuring latency.

## Remaining issue work

Final CI, deployment and an authenticated live model check remain before closing #127. Bounded fixtures prove course behavior, not provider quality or real latency.
