### PR TITLE
Fix course service disclosures and assistant keyboard focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ are defined in [`docs/release_artifacts.md`](docs/release_artifacts.md).
 
 ## Unreleased
 
+- Correct the course license link, explain local conversation storage and remote AI processing,
+  and expose privacy/service links. Use a native modal for Course Assistant keyboard focus.
+  Codex reviewed the added Spanish, Brazilian Portuguese and Chinese wording under maintainer authority.
+
 - Show the questions, replies, and model identities in the ReAct preview, and make optional
   model discovery recover from missing matches or a changed connection. Codex reviewed the
   affected Spanish, Brazilian Portuguese, Simplified Chinese, and Traditional Chinese text

--- a/scripts/security/codeql-vendor-dispositions.json
+++ b/scripts/security/codeql-vendor-dispositions.json
@@ -13,7 +13,7 @@
         }
       ],
       "artifact": "web/nemoclaw/scripts/_course_assistant.js",
-      "artifact_sha256": "5134749b2df060696300833aee6ccaa10fb4406f84b89e54d34d18eeadca6745",
+      "artifact_sha256": "39e05934461524ddf0e951ad692fa240f6d4a466557049c9a8092186a572247c",
       "decision": "opaque-origin-sandbox-execution",
       "owner": "course-maintainers",
       "expires": "2026-10-24",

--- a/tests/runtime/SKILL.html
+++ b/tests/runtime/SKILL.html
@@ -36,6 +36,11 @@
       "desc": "Python source in tests/runtime/."
     },
     {
+      "path": "check_assistant_dialog.mjs",
+      "role": "JavaScript module",
+      "desc": "Javascript module in tests/runtime/."
+    },
+    {
       "path": "course_runtime_fixture.mjs",
       "role": "JavaScript module",
       "desc": "Javascript module in tests/runtime/."
@@ -89,6 +94,7 @@
   <div class="skill-columns">
     <section><h2>Files</h2><ul>
       <li><a href="__init__.py"><code>__init__.py</code></a></li>
+      <li><a href="check_assistant_dialog.mjs"><code>check_assistant_dialog.mjs</code></a></li>
       <li><a href="course_runtime_fixture.mjs"><code>course_runtime_fixture.mjs</code></a></li>
       <li><a href="test_embedded_validator_suites.mjs"><code>test_embedded_validator_suites.mjs</code></a></li>
       <li><a href="test_helper_registry.mjs"><code>test_helper_registry.mjs</code></a></li>

--- a/tests/runtime/check_assistant_dialog.mjs
+++ b/tests/runtime/check_assistant_dialog.mjs
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const { chromium } = createRequire(import.meta.url)('playwright-core');
+const root = path.resolve('web');
+const courses = fs.readdirSync(root).filter(name =>
+  fs.existsSync(path.join(root, name, 'scripts/_course_assistant.js')));
+assert.ok(courses.length, 'No assistant implementation discovered');
+const server = http.createServer((request, response) => {
+  const pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname);
+  const file = path.resolve(root, pathname.replace(/^\/project\//, ''));
+  if (!file.startsWith(root + path.sep) || !fs.existsSync(file) || !fs.statSync(file).isFile()) {
+    response.writeHead(404).end(); return;
+  }
+  const types = { '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' };
+  response.setHeader('Content-Type', types[path.extname(file)] || 'application/octet-stream');
+  response.end(fs.readFileSync(file));
+});
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+let browser;
+try {
+  browser = await chromium.launch({ executablePath: process.env.CHROME_BIN, args: ['--no-sandbox'] });
+  for (const course of courses) {
+    const page = await browser.newPage();
+    const errors = [];
+    page.on('pageerror', error => errors.push(error.message));
+    await page.route('**/*', route => new URL(route.request().url()).origin === origin ? route.continue() : route.abort());
+    await page.goto(`${origin}/project/${course}/index.html`, { waitUntil: 'networkidle' });
+    const launcher = page.locator('.course-assistant-launcher');
+    const panel = page.locator('#course-assistant-panel');
+    assert.equal(await page.locator('.course-license-note a').first().getAttribute('href'),
+      'https://github.com/NVDLI/NemoClawDLI/blob/main/LICENSE');
+    assert.ok(await page.locator('.course-license-note a[href*="privacy-policy"]').count());
+    for (const width of [1280, 390]) {
+      await page.setViewportSize({ width, height: 900 });
+      await launcher.click();
+      assert.equal(await panel.evaluate(node => node.matches(':modal')), true);
+      await page.locator('.course-assistant-resizer').focus();
+      await page.keyboard.press('Shift+Tab');
+      assert.equal(await panel.evaluate(node => node.contains(document.activeElement)), true);
+      await page.keyboard.press('Tab');
+      assert.equal(await panel.evaluate(node => node.contains(document.activeElement)), true);
+      await page.keyboard.press('Escape');
+      assert.equal(await panel.evaluate(node => node.open), false);
+      assert.equal(await launcher.evaluate(node => document.activeElement === node), true);
+    }
+    assert.deepEqual(errors, []);
+    await page.close();
+  }
+  console.log('Assistant modal, keyboard restoration and service links: PASS');
+} finally {
+  await browser?.close();
+  await new Promise(resolve => server.close(resolve));
+}

--- a/tests/validation/SKILL.html
+++ b/tests/validation/SKILL.html
@@ -46,6 +46,11 @@
       "desc": "Python source in tests/validation/."
     },
     {
+      "path": "test_assistant_dialog.py",
+      "role": "Python source",
+      "desc": "Python source in tests/validation/."
+    },
+    {
       "path": "test_build_pages_dependencies.py",
       "role": "Python source",
       "desc": "Python source in tests/validation/."
@@ -266,6 +271,7 @@
       <li><a href="__init__.py"><code>__init__.py</code></a></li>
       <li><a href="test_agent_model_experiment_audit.py"><code>test_agent_model_experiment_audit.py</code></a></li>
       <li><a href="test_artifact_navigation_projection.py"><code>test_artifact_navigation_projection.py</code></a></li>
+      <li><a href="test_assistant_dialog.py"><code>test_assistant_dialog.py</code></a></li>
       <li><a href="test_build_pages_dependencies.py"><code>test_build_pages_dependencies.py</code></a></li>
       <li><a href="test_cell_duplicate_keys.py"><code>test_cell_duplicate_keys.py</code></a></li>
       <li><a href="test_ci_evidence_publication.py"><code>test_ci_evidence_publication.py</code></a></li>

--- a/tests/validation/test_assistant_dialog.py
+++ b/tests/validation/test_assistant_dialog.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the published assistant interface with a real browser."""
+from pathlib import Path
+import unittest
+from scripts.runtime.host_browser import run_node
+
+
+class AssistantDialogTests(unittest.TestCase):
+    def test_modal_keyboard_and_service_links(self):
+        result = run_node(
+            Path(__file__).resolve().parents[1] / 'runtime/check_assistant_dialog.mjs',
+            timeout=90,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)

--- a/web/nemoclaw/scripts/_course_assistant.js
+++ b/web/nemoclaw/scripts/_course_assistant.js
@@ -356,7 +356,7 @@ export function mountCourseAssistant(runtime = {}) {
     saved: "已保存到本地", saving: "正在保存回答", full: "未保存：浏览器存储空间已满", selected: "已选择会话",
     created: "已新建会话", deleted: "已删除会话", renamed: "已重命名会话", attachedNow: "页面已关联到会话", compacted: "上下文已压缩并保存到本地",
     emptyTitle: "新会话", clear: "↺ 清除会话",
-    intro: "会话保存在此浏览器中。系统会自动压缩较早的对话轮次。",
+    intro: /zh-(tw|hant)/.test(language) ? "對話儲存在此瀏覽器中。傳送訊息時，所選 AI 服務會處理提示詞和相關課程內容。請使用虛構、非機密的輸入，並核對回答。" : "对话保存在此浏览器中。发送消息时，所选 AI 服务会处理提示词和相关课程上下文。请使用虚构、非机密的输入，并核查回答。",
     entryTitle: "课程助理",
     entryText: "每个课时中的 ✦ 按钮都可以打开课程助理。每个会话都保存在此浏览器中，并持续关联到会话开始时的页面，直至您明确选择当前页面。",
     entryAction: "打开课程助理",
@@ -379,7 +379,7 @@ export function mountCourseAssistant(runtime = {}) {
     saved: "Salvo localmente", saving: "Salvando resposta", full: "Não salvo: armazenamento local cheio", selected: "Sessão selecionada",
     created: "Nova sessão criada", deleted: "Sessão excluída", renamed: "Sessão renomeada", attachedNow: "Página vinculada à sessão", compacted: "Contexto condensado e salvo localmente",
     emptyTitle: "Nova sessão", clear: "↺ Limpar sessão",
-    intro: "As sessões ficam neste navegador. Turnos antigos são condensados automaticamente.",
+    intro: "As conversas são salvas neste navegador. Ao enviar uma mensagem, o serviço de IA selecionado processa seu prompt e o contexto relevante do curso. Use dados fictícios e não confidenciais e confira as respostas.",
     entryTitle: "Assistente do Curso",
     entryText: "O botão ✦ abre um assistente em todas as lições. Cada sessão fica neste navegador e permanece vinculada à página onde começou até você escolher a página atual.",
     entryAction: "Abrir Assistente do Curso",
@@ -402,7 +402,7 @@ export function mountCourseAssistant(runtime = {}) {
     saved: "Guardado localmente", saving: "Guardando respuesta", full: "No se guardó: el almacenamiento del navegador está lleno", selected: "Sesión seleccionada",
     created: "Nueva sesión creada", deleted: "Sesión eliminada", renamed: "Sesión renombrada", attachedNow: "Página vinculada a la sesión", compacted: "Contexto condensado y guardado localmente",
     emptyTitle: "Nueva sesión", clear: "↺ Borrar sesión",
-    intro: "Las sesiones permanecen en este navegador. Los turnos antiguos se condensan automáticamente.",
+    intro: "Las conversaciones se guardan en este navegador. Al enviar un mensaje, el servicio de IA seleccionado procesa tu prompt y el contexto pertinente del curso. Usa datos ficticios y no confidenciales y verifica las respuestas.",
     entryTitle: "Asistente del curso",
     entryText: "El botón ✦ abre un asistente en cada lección. Cada sesión permanece en este navegador y sigue vinculada a la página donde comenzó hasta que usted elija la página actual.",
     entryAction: "Abrir el Asistente del curso",
@@ -425,7 +425,7 @@ export function mountCourseAssistant(runtime = {}) {
     saved: "Saved locally", saving: "Saving response", full: "Not saved: browser storage is full", selected: "Session selected",
     created: "New session created", deleted: "Session deleted", renamed: "Session renamed", attachedNow: "Page attached to session", compacted: "Compacted and saved locally",
     emptyTitle: "New session", clear: "↺ Clear session",
-    intro: "Sessions stay in this browser. Older turns compact automatically.",
+    intro: "Conversations are saved in this browser. When you send a message, the selected AI service processes your prompt and relevant course context. Use synthetic, nonconfidential inputs and check the answers.",
     entryTitle: "Course Assistant",
     entryText: "The ✦ button opens an assistant on every lesson. Each session stays in this browser and remains attached to the page where it began until you explicitly choose the current page.",
     entryAction: "Open Course Assistant",
@@ -448,8 +448,8 @@ export function mountCourseAssistant(runtime = {}) {
 
   const shell = document.createElement("section");
   shell.className = "course-assistant-shell";
-  shell.innerHTML = `<div class="course-assistant-backdrop" data-course-assistant-close></div>
-    <aside id="course-assistant-panel" class="course-assistant-panel" role="dialog" aria-modal="true" aria-label="${copy.dialog}" aria-hidden="true">
+  shell.innerHTML = `
+    <dialog id="course-assistant-panel" class="course-assistant-panel" aria-label="${copy.dialog}" aria-hidden="true">
       <div class="course-assistant-resizer" role="separator" aria-label="${copy.resize}" aria-orientation="vertical" aria-valuemin="320" tabindex="0" title="${copy.resizeTitle}"></div>
       <header><div><span>${copy.assistant}</span><h2 data-course-assistant-title>${copy.emptyTitle}</h2></div><button type="button" data-course-assistant-close aria-label="${copy.close}">×</button></header>
       <div class="course-assistant-sessions"><label for="course-assistant-session">${copy.session}</label><select id="course-assistant-session" aria-label="${copy.session}"></select><button type="button" data-course-assistant-new>${copy.newSession}</button><button type="button" data-course-assistant-delete aria-label="${copy.deleteLabel}">${copy.deleteSession}</button><input type="text" maxlength="72" aria-label="${copy.renameLabel}" placeholder="${copy.renamePlaceholder}"><span role="status" aria-live="polite"></span></div>
@@ -464,7 +464,7 @@ export function mountCourseAssistant(runtime = {}) {
         <iframe sandbox="allow-scripts" referrerpolicy="no-referrer" title="${copy.artifactPreview}"></iframe>
       </section>
       <section class="course-assistant-history" hidden><header><strong>${copy.historyTitle}</strong><button type="button" data-course-history-copy>${copy.copyHistory}</button></header><pre tabindex="0"></pre></section>
-    </aside>`;
+    </dialog>`;
   document.body.append(launcher, shell);
   if (page.id === "overview" && !document.querySelector(".course-assistant-entry")) {
     const entry = document.createElement("section");
@@ -1159,6 +1159,7 @@ export function mountCourseAssistant(runtime = {}) {
     store.activeId = store.sessions[0].id; mountedSessionId = null; persistStore(copy.deleted); renderArtifact(true); await mountSession();
   });
   const close = () => {
+    panel.close();
     shell.classList.remove("open");
     panel.setAttribute("aria-hidden", "true");
     launcher.setAttribute("aria-expanded", "false");
@@ -1169,11 +1170,23 @@ export function mountCourseAssistant(runtime = {}) {
     shell.classList.add("open");
     panel.setAttribute("aria-hidden", "false");
     launcher.setAttribute("aria-expanded", "true");
+    panel.showModal();
     await mountSession();
-    panel.querySelector("button[data-course-assistant-close]").focus();
+    if (panel.open) panel.querySelector("button[data-course-assistant-close]").focus();
   };
   launcher.addEventListener("click", () => shell.classList.contains("open") ? close() : open());
   shell.querySelectorAll("[data-course-assistant-close]").forEach(el => el.addEventListener("click", close));
+  panel.addEventListener("cancel", event => { event.preventDefault(); close(); });
+  panel.addEventListener("keydown", event => {
+    if (event.key !== 'Tab') return;
+    const controls = [...panel.querySelectorAll('a[href], button, input, select, textarea, iframe, [tabindex]')]
+      .filter(node => !node.disabled && node.tabIndex >= 0 && node.getClientRects().length);
+    const first = controls[0], last = controls.at(-1);
+    const target = event.shiftKey && document.activeElement === first ? last
+      : !event.shiftKey && document.activeElement === last ? first : null;
+    if (target) { event.preventDefault(); target.focus(); }
+  });
+  panel.addEventListener("click", event => { if (event.target === panel && event.clientX < panel.getBoundingClientRect().left) close(); });
   window.addEventListener("keydown", event => { if (event.key === "Escape" && shell.classList.contains("open")) close(); });
 }
 
@@ -1185,11 +1198,39 @@ export function mountCourseLicenseNote() {
   note.className = "course-license-note";
   const language = document.documentElement.lang.toLowerCase();
   note.innerHTML = language.startsWith("zh")
-    ? '课程原创文字、示例代码和原始图表采用 <a href="../../LICENSE">Apache-2.0</a> 许可。注明名称的外部资料沿用各自条款；请参阅<a href="assets/SKILL.html">来源说明</a>。'
+    ? '课程原创文字、示例代码和原始图表采用 <a href="https://github.com/NVDLI/NemoClawDLI/blob/main/LICENSE">Apache-2.0</a> 许可。注明名称的外部资料沿用各自条款；请参阅<a href="assets/SKILL.html">来源说明</a>。'
     : language.startsWith("pt")
-    ? 'Material do curso, código de exemplo e diagramas originais: <a href="../../LICENSE">Apache-2.0</a>. Material externo citado mantém seus próprios termos; veja a <a href="assets/SKILL.html">proveniência</a>.'
+    ? 'Material do curso, código de exemplo e diagramas originais: <a href="https://github.com/NVDLI/NemoClawDLI/blob/main/LICENSE">Apache-2.0</a>. Material externo citado mantém seus próprios termos; veja a <a href="assets/SKILL.html">proveniência</a>.'
     : language.startsWith("es")
-      ? 'Prosa del curso, código de ejemplo y diagramas originales: <a href="../../LICENSE">Apache-2.0</a>. El material externo citado conserva sus propios términos; consulte la <a href="assets/SKILL.html">procedencia</a>.'
-      : 'Course-authored prose, example code, and original diagrams: <a href="../../LICENSE">Apache-2.0</a>. Named external material keeps its own terms; see <a href="assets/SKILL.html">provenance</a>.';
+      ? 'Prosa del curso, código de ejemplo y diagramas originales: <a href="https://github.com/NVDLI/NemoClawDLI/blob/main/LICENSE">Apache-2.0</a>. El material externo citado conserva sus propios términos; consulte la <a href="assets/SKILL.html">procedencia</a>.'
+      : 'Course-authored prose, example code, and original diagrams: <a href="https://github.com/NVDLI/NemoClawDLI/blob/main/LICENSE">Apache-2.0</a>. Named external material keeps its own terms; see <a href="assets/SKILL.html">provenance</a>.';
+  const disclosure = document.createElement('p');
+  disclosure.textContent = /zh-(tw|hant)/.test(language)
+    ? '瀏覽器會儲存對話與課程偏好設定；傳送訊息時，所選 AI 服務會處理輸入。刪除本機工作階段不會刪除服務端紀錄。請使用虛構、非機密的資料，並遵守所選服務的條款。'
+    : language.startsWith('zh')
+    ? '浏览器会保存对话和课程偏好设置；发送消息时，所选 AI 服务会处理输入。删除本地会话不会删除服务端记录。请使用虚构、非机密的数据，并遵守所选服务的条款。'
+    : language.startsWith('pt')
+      ? 'O navegador salva conversas e preferências do curso; ao enviar mensagens, o serviço de IA selecionado processa os dados. Excluir uma sessão local não apaga registros no serviço. Use dados fictícios e não confidenciais e siga os termos do serviço escolhido.'
+      : language.startsWith('es')
+        ? 'El navegador guarda conversaciones y preferencias del curso; al enviar mensajes, el servicio de IA seleccionado procesa los datos. Eliminar una sesión local no borra los registros del servicio. Usa datos ficticios y no confidenciales y cumple los términos del servicio elegido.'
+        : 'The browser saves conversations and course preferences; sending messages uses the selected AI service. Deleting a local session does not delete service records. Use synthetic, nonconfidential data and follow the selected service’s terms.';
+  note.appendChild(disclosure);
+  const links = document.createElement('p');
+  const labels = /zh-(tw|hant)/.test(language) ? ['NVIDIA 隱私權政策', '隱私權利與請求', 'NVIDIA API 試用條款', 'GitHub 託管隱私權說明']
+    : language.startsWith('zh') ? ['NVIDIA 隐私政策', '隐私权利与请求', 'NVIDIA API 试用条款', 'GitHub 托管隐私说明']
+    : language.startsWith('pt') ? ['Privacidade da NVIDIA', 'Direitos e solicitações de privacidade', 'Termos de avaliação da API NVIDIA', 'Privacidade da hospedagem GitHub']
+      : language.startsWith('es') ? ['Privacidad de NVIDIA', 'Derechos y solicitudes de privacidad', 'Términos de prueba de la API de NVIDIA', 'Privacidad del alojamiento en GitHub']
+        : ['NVIDIA privacy policy', 'Privacy rights and requests', 'NVIDIA API trial terms', 'GitHub hosting privacy'];
+  [
+    'https://www.nvidia.com/en-us/about-nvidia/privacy-policy/',
+    'https://www.nvidia.com/en-us/about-nvidia/privacy-center/',
+    'https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf',
+    'https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement',
+  ].forEach((href, index) => {
+    if (index) links.append(' · ');
+    const link = document.createElement('a');
+    link.href = href; link.textContent = labels[index]; links.appendChild(link);
+  });
+  note.appendChild(links);
   main.appendChild(note);
 }

--- a/web/nemoclaw/styles/_style.css
+++ b/web/nemoclaw/styles/_style.css
@@ -232,8 +232,9 @@ body * { overscroll-behavior: contain; }
 .course-assistant-entry > .course-assistant-open { grid-column: 2; justify-self: end; white-space: nowrap; }
 .course-assistant-shell { display: none; }
 .course-assistant-shell.open { display: block; }
-.course-assistant-backdrop { position: fixed; inset: 0; z-index: 119; background: rgba(0,0,0,.42); }
+.course-assistant-panel::backdrop { background: rgba(0,0,0,.42); }
 .course-assistant-panel {
+  margin: 0 0 0 auto; padding: 0; border: 0; color: var(--td); max-height: 100dvh;
   position: fixed; z-index: 120; top: 0; right: 0; width: min(30rem, 90vw); max-width: 90vw; height: 100dvh;
   display: flex; flex-direction: column; overflow: hidden; border-left: 1px solid var(--bd); background: var(--bg);
   box-shadow: -12px 0 32px rgba(0,0,0,.35);


### PR DESCRIPTION
## Summary

Repair the course license link, explain browser storage versus remote AI processing, expose privacy and service terms, and keep keyboard focus inside the Course Assistant dialog.

## Issue link

Addresses #126. Complements Lisa Guo's Activity SDK proposal #124.

## Surfaces touched

- [x] `web/`
- [x] `scripts/`
- [x] Tests and generated indexes

Shared Course Assistant interface, styles, browser regression tests, generated test-directory indexes, and changelog. Added wording covers Spanish, Brazilian Portuguese, Simplified Chinese and Taiwan Traditional Chinese.

## Blast radius checked

Desktop/mobile assistant interaction, project subpaths, shared license/privacy links, generated indexes, source integrity and existing dependency inventory. Dependency packages and vendored asset bytes are unchanged.

## Validation evidence

PASS: `python3 -m unittest tests.validation.test_assistant_dialog` on SSH at desktop and mobile widths: backward/forward tabbing, Escape, focus restoration and license/privacy links. PASS: source, dependency and CodeQL policy checks. The CodeQL artifact digest was refreshed after verifying the unchanged sandbox boundary. Required CI and independent review remain separate gates.

PASS: 70 fast suites on the reviewed tree, then all 93 ship suites and the Pages build on signed commit `78eb76e1fb437a22bf371834d5a7be4ddc5c2c1f`. Full validation discovery passed 521 tests. Artifact navigation, links and publication integrity passed, and the build left tracked source clean. The browser test also passes without runner-specific `NODE_PATH` or `CHROME_BIN` overrides.

## Human ownership

Vadim Kudlay maintains this follow-up; Codex prepared and reviewed the wording under maintainer authority. Lisa Guo retains feature ownership and contributor credit for #124.

## Risk and rollback

The assistant now uses a native modal with keyboard wrapping. Revert this focused change if an interaction regression is found. Privacy links describe existing service boundaries and do not attest operator approval.

## Out of scope

Activity collection enablement, service-owner/privacy approval, promotion eligibility, material redistribution permissions, and production deployment.

## Remaining issue work

The Activity integration still needs its client-control candidate and service-policy evidence reviewed, plus exact-head release and live-service validation. This follow-up does not close #126 or replace Lisa's SDK contribution.
